### PR TITLE
Enable previewing of normal (non-embedded) glTF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.0.5 - Unreleased
 
 * Normal (non-embedded) glTF files can now be previewed.
+* Multiple preview windows can now be opened at the same time.
 
 ### 1.0.4 - 2017-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.0.5 - 2017-05-12
+
+* Normal (non-embedded) glTF files can now be previewed.
+
 ### 1.0.4 - 2017-05-06
 
 * Data preview (<kbd>alt</kbd> + <kbd>d</kbd>) works with external files now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### 1.0.5 - 2017-05-12
+### 1.0.5 - Unreleased
 
 * Normal (non-embedded) glTF files can now be previewed.
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ Press <kbd>ALT</kbd> + <kbd>G</kbd> on your glTF file, or look for the command `
 
 #### glTF compatibility and sample models
 
-This extension is only able to preview data that is embedded in the glTF file itself.  It does not fetch data from external references, even if they are in the same folder as the glTF file (this may change in some future version).
-
-There are some [sample glTF 1.0 models online](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/1.0) that can be downloaded, and each model comes in several flavors.  Currently this extension can be used to edit (but not preview) all the text-based versions (`*.gltf`), not binary versions (`*.glb`).  The preview functions are slightly more limited than that.  They work only with the `glTF-Embedded` flavor, not the glTF "separate files" version.  For example, to see the demo "Avocado" model, you would avoid the [separate files folder](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/1.0/Avocado/glTF) and instead download the single [Avocado.gltf](https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/1.0/Avocado/glTF-Embedded/Avocado.gltf) file with all textures and resources embedded inside it.
+There are some [sample glTF 1.0 models online](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/1.0) that can be downloaded, and each model comes in several flavors.  Currently this extension can be used to edit (and preview) all the text-based versions (`*.gltf`), not binary versions (`*.glb`).
 
 ### &bull;  Preview embedded dataURIs
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gltf-vscode",
     "displayName": "glTF Tools",
     "description": "Tools for editing and previewing glTF 1.0 files",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "publisher": "cesium",
     "license": "Apache-2.0",
     "repository": {

--- a/pages/previewModel.html
+++ b/pages/previewModel.html
@@ -9,7 +9,6 @@
     <script src="${this.getFilePath('Cesium/Cesium.js')}"></script>
     <script id="gltf" type="text/plain">${gltfContent}</script>
     <script id="gltfRootPath" type="text/plain">${gltfRootPath}</script>
-    <script id="gltfFileName" type="text/plain">${gltfFileName}</script>
 </head>
 <body>
     <div id="cesiumContainer">

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -69,11 +69,52 @@ function setCamera(scene, model) {
     scene.camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, range));
 }
 
-function loadModel(gltf, resetCamera) {
+// function loadModel(gltf, resetCamera) {
+//     scene.primitives.removeAll();
+//     var model = scene.primitives.add(new Cesium.Model({
+//         gltf: gltf
+//     }));
+
+//     Cesium.when(model.readyPromise).then(function(model) {
+//         if (Cesium.Cartesian3.magnitude(Cesium.Cartesian3.subtract(model.boundingSphere.center, Cesium.Cartesian3.ZERO, new Cesium.Cartesian3())) < 5000000) {
+//             model.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(new Cesium.Cartesian3.fromDegrees(0.0, 89.999, 0.0));
+//         }
+
+//         if (resetCamera) {
+//             setCamera(scene, model);
+//         }
+
+//         viewer._model = model;
+//         viewer.onLoad.raiseEvent(model);
+//     }).otherwise(function(e){
+//         window.alert('Error: ' + e);
+//     });
+// }
+
+// var gltf = JSON.parse(document.getElementById('glTF').textContent);
+
+// loadModel(gltf, true);
+
+
+
+
+function loadModel(gltfContent, gltfRootPath, gltfFileName, resetCamera) {
     scene.primitives.removeAll();
-    var model = scene.primitives.add(new Cesium.Model({
-        gltf: gltf
-    }));
+
+    var model = null;
+    if (gltfContent === null)
+    {
+        model = scene.primitives.add(Cesium.Model.fromGltf({
+            url: gltfRootPath.replace(/\\/g, "\\\\") + "\\" + gltfFileName,
+        }));
+    }
+    else
+    {
+        model = scene.primitives.add(new Cesium.Model({
+            gltf: gltfContent,
+            basePath: gltfRootPath.replace(/\\/g, "\\\\")
+        }));
+    }
 
     Cesium.when(model.readyPromise).then(function(model) {
         if (Cesium.Cartesian3.magnitude(Cesium.Cartesian3.subtract(model.boundingSphere.center, Cesium.Cartesian3.ZERO, new Cesium.Cartesian3())) < 5000000) {
@@ -86,11 +127,18 @@ function loadModel(gltf, resetCamera) {
 
         viewer._model = model;
         viewer.onLoad.raiseEvent(model);
-    }).otherwise(function(e){
+    }).otherwise(function(e) {
         window.alert('Error: ' + e);
     });
 }
 
-var gltf = JSON.parse(document.getElementById('glTF').textContent);
+var gltfContent = null;
+try {
+    gltfContent = JSON.parse(document.getElementById('gltf').textContent);
+}
+catch (ex) { /* eat the exception */ }
 
-loadModel(gltf, true);
+var gltfFileName = document.getElementById('gltfFileName').textContent;
+var gltfRootPath = document.getElementById('gltfRootPath').textContent;
+
+loadModel(gltfContent, gltfRootPath, gltfFileName, true);

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -74,15 +74,7 @@ function loadModelFromContent(gltfContent, gltfRootPath, resetCamera) {
 
     var model = scene.primitives.add(new Cesium.Model({
         gltf: gltfContent,
-
-        // In theory, by specifying basePath, we should be able to have relative paths
-        // within the glTFContent.  In practice, specifying basePath makes no difference.
-        // This is likely a bug in Cesium (tracked by https://github.com/AnalyticalGraphicsInc/cesium/issues/5319).
-        // For now, we'll continue with specifying the basePath here, but we'll also
-        // make sure that all paths in glTFContent are absolute to work around the bug.
-        // That logic happens at the time when the content gets written to the script
-        // tag in the HTML.
-        basePath: gltfRootPath.replace(/\\/g, "\\\\") + "\\"
+        basePath: "file:///" + gltfRootPath
     }));
 
     loadModel(model, resetCamera);
@@ -92,7 +84,7 @@ function loadModelFromFile(gltfFileName, gltfRootPath, resetCamera) {
     scene.primitives.removeAll();
 
     var model = scene.primitives.add(Cesium.Model.fromGltf({
-        url: gltfRootPath.replace(/\\/g, "\\\\") + "\\" + gltfFileName,
+        url: "file:///" + gltfRootPath + gltfFileName,
 
         // Unfortunately, Cesium does not currently allow a basePath to be specified
         // when loading a glTF file...that means it only works with glTF files that

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -72,24 +72,14 @@ function setCamera(scene, model) {
 function loadModelFromContent(gltfContent, gltfRootPath, resetCamera) {
     scene.primitives.removeAll();
 
+    if (!gltfRootPath.startsWith("file://"))
+    {
+        gltfRootPath = "file:///" + gltfRootPath;
+    }
+
     var model = scene.primitives.add(new Cesium.Model({
         gltf: gltfContent,
-        basePath: "file:///" + gltfRootPath
-    }));
-
-    loadModel(model, resetCamera);
-}
-
-function loadModelFromFile(gltfFileName, gltfRootPath, resetCamera) {
-    scene.primitives.removeAll();
-
-    var model = scene.primitives.add(Cesium.Model.fromGltf({
-        url: "file:///" + gltfRootPath + gltfFileName,
-
-        // Unfortunately, Cesium does not currently allow a basePath to be specified
-        // when loading a glTF file...that means it only works with glTF files that
-        // use absolute paths internally.  This Cesium feature request is tracked by
-        // https://github.com/AnalyticalGraphicsInc/cesium/issues/5320.
+        basePath: gltfRootPath
     }));
 
     loadModel(model, resetCamera);
@@ -112,15 +102,6 @@ function loadModel(model, resetCamera) {
     });
 }
 
-var gltfFileName = document.getElementById('gltfFileName').textContent;
 var gltfRootPath = document.getElementById('gltfRootPath').textContent;
-
-try {
-    var gltfContent = JSON.parse(document.getElementById('gltf').textContent);
-    loadModelFromContent(gltfContent, gltfRootPath, true);
-}
-catch (ex) {
-    // If the glTF content is missing or not valid JSON, then try to load the
-    // model directly from the glTF file.
-    loadModelFromFile(gltfFileName, gltfRootPath, true);
-}
+var gltfContent = JSON.parse(document.getElementById('gltf').textContent);
+loadModelFromContent(gltfContent, gltfRootPath, true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,11 +249,12 @@ export function activate(context: vscode.ExtensionContext) {
     //
     const gltfPreviewProvider = new GltfPreviewDocumentContentProvider(context);
     const gltfPreviewRegistration = vscode.workspace.registerTextDocumentContentProvider('gltf-preview', gltfPreviewProvider);
-    const gltfPreviewUri = Uri.parse('gltf-preview://gltf-vscode/gltf-preview');
     context.subscriptions.push(gltfPreviewRegistration);
 
     context.subscriptions.push(vscode.commands.registerCommand('gltf.previewModel', () => {
-        vscode.commands.executeCommand('vscode.previewHtml', gltfPreviewUri, ViewColumn.Two, 'glTF Preview')
+        const fileName = path.basename(vscode.window.activeTextEditor.document.fileName);
+        const gltfPreviewUri = Uri.parse(gltfPreviewProvider.UriPrefix + encodeURIComponent(vscode.window.activeTextEditor.document.fileName));
+        vscode.commands.executeCommand('vscode.previewHtml', gltfPreviewUri, ViewColumn.Two, `glTF Preview [${fileName}]`)
         .then((success) => {}, (reason) => { vscode.window.showErrorMessage(reason); });
 
         // This can be used to debug the preview HTML.

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -1,6 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import { ExtensionContext, TextDocumentContentProvider, EventEmitter, Event, Uri, ViewColumn } from 'vscode';
 
 export class GltfPreviewDocumentContentProvider implements TextDocumentContentProvider {
@@ -15,8 +16,30 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
         return 'file://' + this._context.asAbsolutePath(file);
     }
 
+    // credit: http://stackoverflow.com/a/30714706
+    private isAbsolute(pathToTest : string) : boolean {
+        return path.normalize(pathToTest + '/') === path.normalize(path.resolve(pathToTest) + '/');
+    }
+
+    private fixPaths(gltfObject: object, gltfRootPath: string) {
+        for (var property in gltfObject) {
+            if (gltfObject.hasOwnProperty(property)) {
+                if (typeof gltfObject[property] == "object") {
+                    this.fixPaths(gltfObject[property], gltfRootPath);
+                } else if (property === "uri") {
+                    if (gltfObject[property].match((/^([^(data)]\S*)$/i)) && !this.isAbsolute(gltfObject[property]))
+                    {
+                        gltfObject[property] = gltfRootPath.replace(/\\/g, "\\\\") + "\\" + gltfObject[property];
+                    }
+                }
+            }
+        }
+    }
+
     public provideTextDocumentContent(uri: Uri): string {
-        const glTF = vscode.window.activeTextEditor.document.getText();
+        const gltfRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
+        const gltfFileName = path.basename(vscode.window.activeTextEditor.document.fileName);
+        var gltfContent = vscode.window.activeTextEditor.document.getText();
 
         // The "uri" property within a glTF file provides the reference to the binary content needed
         // for the glTF to be processed.  The content of that property is likely to fall into one of
@@ -25,20 +48,31 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
         // 2. A partial path to the file.
         // 3. A full path (or full Uri reference)
         // 4. The full binary content base-64 encoded with a content-type header.
-        //    a full path specified for their uri.  If they don't have a full path specified,
+        //
         // If we don't make any changes to the glTF content, #3 and #4 work just fine with 3D renderers.
         // Unfortunately, #1 and #2 are considered to be paths relative to the "pages" subfolder of this
         // extension, and so those references fail to load.  So, we'll look for any "uri" property that
-        // doesn't have a forward or backward slash in it (even #4 has at least one of those due to the
-        // content-type header), and we'll prepend the root folder that the glTF file content lives in.
-        // This solves for #1, but unfortunately it doesn't yet solve for #2.
-        const glTFRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
-        const glTFWithUpdatedPaths = glTF.replace(
-            // Find all uri property entries that don't have a forward or backward slash in them.
-            /^(\s*"uri"\s*:\s*")([^/\\\s]*)(".*)$/igm,
-            // And replace the property content with the root path of where the glTF file currently sits
-            // (making sure that all backslashes are escaped)
-            "$1" + glTFRootPath.replace(/\\/g,"\\\\") + "\\\\$2$3");
+        // doesn't start with "data" (which would make it #4) and test the path to see if it's absolute
+        // or not.  If it's not absolute, we'll prepend the root folder that the glTF file content
+        // originated from.  This should ensure that both #1 and #2 work as well.
+        var regex = new RegExp(/^(\s*"uri"\s*:\s*")([^(data)]\S*)(".*)$/gim);
+        var match;
+        while (match = regex.exec(gltfContent))
+        {
+            var uriToCheck = match[2];
+            if (!this.isAbsolute(uriToCheck))
+            {
+                // match[0] is the full content matched
+                // match[1] is essentially "uri":"
+                // match[2] is what is inside the quotes for the uri property value
+                // match[3] is the end-quote for the property value and anything else that might have been on
+                //gltfContent = gltfContent.replace(match[0], match[1] + gltfRootPath.replace(/\\/g, "\\\\") + "\\" + match[2] + match[3]);
+            }
+        }
+
+        var gltf = JSON.parse(gltfContent);
+        this.fixPaths(gltf, gltfRootPath);
+        gltfContent = JSON.stringify(gltf);
 
         const content = `<!DOCTYPE html>
 <html lang="en">
@@ -49,7 +83,9 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     <title>glTF Preview</title>
     <link rel="stylesheet" href="${this.getFilePath('pages/previewModel.css')}">
     <script src="${this.getFilePath('Cesium/Cesium.js')}"></script>
-    <script id="glTF" type="text/plain">${glTFWithUpdatedPaths}</script>
+    <script id="gltf" type="text/plain">${gltfContent}</script>
+    <script id="gltfRootPath" type="text/plain">${gltfRootPath}</script>
+    <script id="gltfFileName" type="text/plain">${gltfFileName}</script>
 </head>
 <body>
     <div id="cesiumContainer">
@@ -61,6 +97,17 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
 </body>
 </html>
 `;
+
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        fs.writeFileSync(this._context.asAbsolutePath('pages\\rendered.html'), content);
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+        // DEBUG DEBUG DEBUG -- Remove this before pull request
+
         return content;
     }
 

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -12,62 +12,16 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     }
 
     private getFilePath(file : string) : string {
-        return 'file://' + this._context.asAbsolutePath(file);
-    }
-
-    // credit: http://stackoverflow.com/a/30714706
-    private isAbsolutePath(pathToTest : string) : boolean {
-        return path.normalize(pathToTest + '/') === path.normalize(path.resolve(pathToTest) + '/');
-    }
-
-    /**
-    * @function fixPaths
-    * Does an in-place update of the provided gltfObject to ensure that all 'uri' properties are absolute paths.
-    * @param  {object} gltfObject The glTF content in object form
-    * @param  {string} gltfRootPath The root path that the glTF object is located in (which is where any relative binary files might be referenced from)
-    */
-    private fixPaths(gltfObject: object, gltfRootPath: string) {
-        if (!gltfRootPath.endsWith("\\"))
-        {
-            gltfRootPath = gltfRootPath + "\\";
-        }
-
-        for (var property in gltfObject) {
-            if (gltfObject.hasOwnProperty(property)) {
-                if (typeof gltfObject[property] == "object") {
-                    this.fixPaths(gltfObject[property], gltfRootPath);
-                } else if (property === "uri") {
-                    if (!gltfObject[property].startsWith('data:') && !this.isAbsolutePath(gltfObject[property]))
-                    {
-                        gltfObject[property] = gltfRootPath + gltfObject[property];
-                    }
-                }
-            }
-        }
+        return 'file:///' + this._context.asAbsolutePath(file);
     }
 
     public provideTextDocumentContent(uri: Uri): string {
-        const gltfRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
+        const gltfContent = vscode.window.activeTextEditor.document.getText();
         const gltfFileName = path.basename(vscode.window.activeTextEditor.document.fileName);
-
-        // The "uri" property within a glTF file provides the reference to the binary content needed
-        // for the glTF to be processed.  The content of that property is likely to fall into one of
-        // four categories:
-        // 1. Just the binary filename
-        // 2. A partial path to the file.
-        // 3. A full path (or full Uri reference)
-        // 4. The full binary content base-64 encoded with a content-type header.
-        //
-        // If we don't make any changes to the glTF content, #3 and #4 work just fine with 3D renderers.
-        // Unfortunately, #1 and #2 are considered to be paths relative to the "pages" subfolder of this
-        // extension, and so those references fail to load.  So, we'll look for any "uri" property that
-        // doesn't start with "data" (which would make it #4) and test the path to see if it's absolute
-        // or not.  If it's not absolute, we'll prepend the root folder that the glTF file content
-        // originated from.  This should ensure that both #1 and #2 work as well.
-        var gltfContent = vscode.window.activeTextEditor.document.getText();
-        var gltf = JSON.parse(gltfContent);
-        this.fixPaths(gltf, gltfRootPath);
-        gltfContent = JSON.stringify(gltf);
+        let gltfRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName).replace('\\', '/');
+        if (!gltfRootPath.endsWith("/")) {
+            gltfRootPath += "/";
+        }
 
         const content = `<!DOCTYPE html>
 <html lang="en">

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -17,6 +17,29 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
 
     public provideTextDocumentContent(uri: Uri): string {
         const glTF = vscode.window.activeTextEditor.document.getText();
+
+        // The "uri" property within a glTF file provides the reference to the binary content needed
+        // for the glTF to be processed.  The content of that property is likely to fall into one of
+        // four categories:
+        // 1. Just the binary filename
+        // 2. A partial path to the file.
+        // 3. A full path (or full Uri reference)
+        // 4. The full binary content base-64 encoded with a content-type header.
+        //    a full path specified for their uri.  If they don't have a full path specified,
+        // If we don't make any changes to the glTF content, #3 and #4 work just fine with 3D renderers.
+        // Unfortunately, #1 and #2 are considered to be paths relative to the "pages" subfolder of this
+        // extension, and so those references fail to load.  So, we'll look for any "uri" property that
+        // doesn't have a forward or backward slash in it (even #4 has at least one of those due to the
+        // content-type header), and we'll prepend the root folder that the glTF file content lives in.
+        // This solves for #1, but unfortunately it doesn't yet solve for #2.
+        const glTFRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
+        const glTFWithUpdatedPaths = glTF.replace(
+            // Find all uri property entries that don't have a forward or backward slash in them.
+            /^(\s*"uri"\s*:\s*")([^/\\\s]*)(".*)$/igm,
+            // And replace the property content with the root path of where the glTF file currently sits
+            // (making sure that all backslashes are escaped)
+            "$1" + glTFRootPath.replace(/\\/g,"\\\\") + "\\\\$2$3");
+
         const content = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -26,7 +49,7 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     <title>glTF Preview</title>
     <link rel="stylesheet" href="${this.getFilePath('pages/previewModel.css')}">
     <script src="${this.getFilePath('Cesium/Cesium.js')}"></script>
-    <script id="glTF" type="text/plain">${glTF}</script>
+    <script id="glTF" type="text/plain">${glTFWithUpdatedPaths}</script>
 </head>
 <body>
     <div id="cesiumContainer">

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -37,7 +37,7 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
                 if (typeof gltfObject[property] == "object") {
                     this.fixPaths(gltfObject[property], gltfRootPath);
                 } else if (property === "uri") {
-                    if (gltfObject[property].match((/^([^(data)]\S*)$/i)) && !this.isAbsolutePath(gltfObject[property]))
+                    if (!gltfObject[property].startsWith('data:') && !this.isAbsolutePath(gltfObject[property]))
                     {
                         gltfObject[property] = gltfRootPath + gltfObject[property];
                     }

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -7,6 +7,8 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     private _onDidChange = new EventEmitter<Uri>();
     private _context: ExtensionContext;
 
+    public UriPrefix = 'gltf-preview://';
+
     constructor(context: ExtensionContext) {
         this._context = context;
     }
@@ -16,9 +18,15 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     }
 
     public provideTextDocumentContent(uri: Uri): string {
-        const gltfContent = vscode.window.activeTextEditor.document.getText();
-        const gltfFileName = path.basename(vscode.window.activeTextEditor.document.fileName);
-        let gltfRootPath = path.dirname(vscode.window.activeTextEditor.document.fileName).replace('\\', '/');
+        const fileName = decodeURIComponent(uri.authority);
+        const document = vscode.workspace.textDocuments.find(e => e.fileName.toLowerCase() === fileName.toLowerCase());
+        if (!document) {
+            vscode.window.showErrorMessage('Can no longer find document in editor: ' + fileName);
+            return undefined;
+        }
+
+        const gltfContent = document.getText();
+        let gltfRootPath = path.dirname(fileName).replace('\\', '/');
         if (!gltfRootPath.endsWith("/")) {
             gltfRootPath += "/";
         }
@@ -34,7 +42,6 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
     <script src="${this.getFilePath('Cesium/Cesium.js')}"></script>
     <script id="gltf" type="text/plain">${gltfContent}</script>
     <script id="gltfRootPath" type="text/plain">${gltfRootPath}</script>
-    <script id="gltfFileName" type="text/plain">${gltfFileName}</script>
 </head>
 <body>
     <div id="cesiumContainer">


### PR DESCRIPTION
We can now preview glTF files that aren't embedded (so, the binary content is external to the glTF file and referenced by its filename in the `uri` property).

We leverage the fact that we can specify a `basePath` in Cesium when loading raw glTF content by providing the root folder that the glTF file is stored in.

This change also resolves Issue #1, allowing multiple preview windows to be opened at the same time (one per glTF file).