### PR TITLE
Minor cleanup

### DIFF
--- a/schemas/gltf-2.0/accessor.schema.json
+++ b/schemas/gltf-2.0/accessor.schema.json
@@ -74,7 +74,7 @@
         },
         "normalized" : {
             "type" : "boolean",
-            "description" : "Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or [-1, 1] (for signed types), or converted directly (`false`) when they are accessed. This property is defined only for accessors that contain vertex attributes or morph weights animation data.",
+            "description" : "Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or [-1, 1] (for signed types), or converted directly (`false`) when they are accessed. This property is defined only for accessors that contain vertex attributes or animation output data.",
             "default" : false,
             "gltf_webgl" : "`vertexAttribPointer()` normalized parameter",
             "short_description" : "Specifies whether integer data values should be normalized."

--- a/schemas/gltf-2.0/animation.sampler.schema.json
+++ b/schemas/gltf-2.0/animation.sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema" : "http://json-schema.org/draft-04/schema",
-    "title" : "animation sampler",
+    "title" : "sampler",
     "type" : "object",
     "description" : "Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
     "allOf" : [

--- a/schemas/gltf-2.0/node.schema.json
+++ b/schemas/gltf-2.0/node.schema.json
@@ -75,7 +75,9 @@
             "type" : "array",
             "description" : "The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.",
             "items" : {
-                "type" : "number"
+                "type" : "number",
+                "minimum" : -1,
+                "maximum" : 1
             },
             "minItems" : 4,
             "maxItems" : 4,

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -52,7 +52,7 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
         var gltfMajorVersion = 1;
         try {
             const gltf = JSON.parse(gltfContent);
-            if (gltf && gltf.asset && gltf.asset.version && gltf.asset.version && gltf.asset.version[0] === '2') {
+            if (gltf && gltf.asset && gltf.asset.version && gltf.asset.version[0] === '2') {
                 gltfMajorVersion = 2;
             }
         } catch (ex) { }


### PR DESCRIPTION
* Re-ran the glTF 2.0 schema import script, to pick up a couple of last changes that happened between the final draft and the released version.

* Removed a duplicate check for `gltf.asset.version` being defined.
