### PR TITLE
Update cameras for all three engines to look at +Z forward assets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.0.8 - UNRELEASED
 
 * Added an option to import a`.glb` binary package file.
+* Default camera view in all three engines updated for glTF's new +Z forward convention for models.
 * Updated logo for Babylon.js.
 * Revealed more error messages from Babylon and Cesium.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added an option to import a`.glb` binary package file.
 * Default camera view in all three engines updated for glTF's new +Z forward convention for models.
+* Model is automatically sized and centered in all three engines now.
 * Updated logo for Babylon.js.
 * Revealed more error messages from Babylon and Cesium.
 

--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -54,6 +54,9 @@ var BabylonView = function() {
         BABYLON.SceneLoader.Append(rootPath, 'data:' + gltfContent, scene, function() {
             scene.createDefaultCameraOrLight(true);
             scene.activeCamera.attachControl(canvas);
+            // glTF assets use a +Z forward convention while the default camera faces +Z.
+            // Rotate the camera to look at the front of the asset.
+            scene.activeCamera.alpha += Math.PI;
             scene.environmentTexture = BABYLON.CubeTexture.CreateFromPrefilteredData(
                 defaultBabylonReflection, scene);
 

--- a/pages/cesiumView.js
+++ b/pages/cesiumView.js
@@ -77,9 +77,9 @@ var CesiumView = function() {
         controller.minimumZoomDistance = 0.0;
 
         var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        var heading = Cesium.Math.toRadians(-130.0);
-        var pitch = Cesium.Math.toRadians(-25.0);
-        var range = r * 3.5;
+        var heading = Cesium.Math.toRadians(10);
+        var pitch = Cesium.Math.toRadians(-15);
+        var range = r * 2.5;
 
         scene.camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, range));
     }


### PR DESCRIPTION
Fixes #45.

Also fixes ThreeJS viewer to take model bounding box and center into account.