### PR TITLE
Fixed small bug related to missing `byteOffset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.0.9 - UNRELEASED
+
+* Fixed bug where a small error could slip into a `.glb` file due to a missing `byteOffset` value in a `.gltf` file.
+
 ### 2.0.8 - 2017-11-04
 
 * Added an option to import a`.glb` binary package file.

--- a/src/exportProvider.ts
+++ b/src/exportProvider.ts
@@ -73,7 +73,7 @@ export function save(gltf: any, sourceFilename: string, outputFilename: string) 
     }
     for (let bufferView of gltf.bufferViews)
     {
-        bufferView.byteOffset = bufferView.byteOffset + bufferMap.get(bufferView.buffer);
+        bufferView.byteOffset = (bufferView.byteOffset || 0) + bufferMap.get(bufferView.buffer);
         bufferView.buffer = 0;
     }
 


### PR DESCRIPTION
The `Lantern.gltf` sample model contains a `bufferView` that is lacking a `byteOffset`, relying on the default offset of zero, on [lines 129-132 of Lantern.gltf](https://github.com/KhronosGroup/glTF-Sample-Models/blob/5bdbcd0b7dced77c7dbb0e5772426bb23f937c1e/2.0/Lantern/glTF/Lantern.gltf#L129-L132).

When exporting this to GLB, the missing value was `undefined`, but was added to another value which turned it into a `NaN`, and then serialized to JSON which turned it into `null`.  The resulting GLB file then contained the string `"byteOffset":null`.  The three web-based engines included here have no problem with this null value, but it's technically not up to spec, and the desktop-based Win10 Mixed Reality Viewer will choke on this value and show a model of a sad seagull or something.

This change fixes it to do the math correctly.

/cc KhronosGroup/glTF-Validator#34