### PR TITLE
Schema update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Workaround for https://github.com/npm/npm/issues/17161
 package*.json text eol=lf
+
+# Because these are generated as such
+schemas/*/*.json text eol=lf

--- a/schemas/gltf-1.0/buffer.schema.json
+++ b/schemas/gltf-1.0/buffer.schema.json
@@ -15,7 +15,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_uriType" : "application",
             "short_description" : "The uri of the buffer."
         },

--- a/schemas/gltf-1.0/image.schema.json
+++ b/schemas/gltf-1.0/image.schema.json
@@ -15,7 +15,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg, png, bmp, or gif.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_uriType" : "image",
             "short_description" : "The uri of the image."
         }

--- a/schemas/gltf-1.0/shader.schema.json
+++ b/schemas/gltf-1.0/shader.schema.json
@@ -15,7 +15,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the GLSL source.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_uriType" : "text",
             "short_description" : "The uri of the GLSL source."
         },

--- a/schemas/gltf-2.0/sampler.schema.json
+++ b/schemas/gltf-2.0/sampler.schema.json
@@ -78,7 +78,7 @@
             "short_description" : "Minification filter."
         },
         "wrapS" : {
-            "description" : "s wrapping mode.  All valid values correspond to WebGL enums.",
+            "description" : "S (U) wrapping mode.  All valid values correspond to WebGL enums.",
             "default" : 10497,
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_S",
             "anyOf" : [
@@ -107,7 +107,7 @@
             "short_description" : "s wrapping mode."
         },
         "wrapT" : {
-            "description" : "t wrapping mode.  All valid values correspond to WebGL enums.",
+            "description" : "T (V) wrapping mode.  All valid values correspond to WebGL enums.",
             "default" : 10497,
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_T",
             "anyOf" : [

--- a/schemas/gltf-2.0/textureInfo.schema.json
+++ b/schemas/gltf-2.0/textureInfo.schema.json
@@ -18,7 +18,7 @@
         },
         "texCoord" : {
             "type" : "integer",
-            "description" : "This integer value is used to construct a string in the format TEXCOORD_<set index> which is a reference to a key in mesh.primitives.attributes (e.g. A value of 0 corresponds to TEXCOORD_0).",
+            "description" : "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.",
             "default" : 0,
             "minimum" : 0,
             "short_description" : "The set index of texture's TEXCOORD attribute used for texture coordinate mapping."

--- a/util/importSchema.js
+++ b/util/importSchema.js
@@ -130,11 +130,29 @@ function upgradeDescriptions(data) {
     }
 }
 
+function upgradeUriRefs(data) {
+    for (var key in data) {
+        if (data.hasOwnProperty(key)) {
+            var val = data[key];
+            if (typeof(val) === 'object') {
+                upgradeUriRefs(val);
+            }
+        }
+    }
+
+    // See: https://github.com/KhronosGroup/glTF/issues/1149
+    if (data && data.format && data.format === 'uri') {
+        console.log('NOTE: uri upgraded to uriref.');
+        data.format = 'uriref';
+    }
+}
+
 function transformFile(inputFile, outputFile) {
     var schema = JSON.parse(fs.readFileSync(inputFile));
 
     transformEnums(schema);
     upgradeDescriptions(schema);
+    upgradeUriRefs(schema);
 
     fs.writeFileSync(outputFile, JSON.stringify(schema, null, '    ').replace(/\"\:/g, '" :') + '\n');
 }


### PR DESCRIPTION
Only minor wording changes as a result of a re-import of glTF 2.0 schemas.

Also applied a workaround for the glTF 1.0 `uriref` issue, KhronosGroup/glTF#1149.