### PR TITLE
UTF-8 scripts

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "compile",
+            "label": "compile",
             "dependsOn": [
                 "compile:client",
                 "compile:server"
@@ -36,7 +36,7 @@
             ]
         },
         {
-            "taskName": "watch",
+            "label": "watch",
             "dependsOn": [
                 "watch:client",
                 "watch:server"

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -114,10 +114,11 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
             'pages/previewModel.js'
         ];
 
+        // Note that with the file: protocol, we must manually specify the UTF-8 charset.
         const content = this._mainHtml.replace('{assets}',
             styles.map(s => `<link rel="stylesheet" href="${this.getFilePath(s)}"></link>\n`).join('') +
-            strings.map(s => `<script id="${s.id}" type="text/plain">${s.text}</script>\n`).join('') +
-            scripts.map(s => `<script type="text/javascript" src="${this.getFilePath(s)}"></script>\n`).join(''));
+            strings.map(s => `<script id="${s.id}" type="text/plain" charset="UTF-8">${s.text}</script>\n`).join('') +
+            scripts.map(s => `<script type="text/javascript" charset="UTF-8" src="${this.getFilePath(s)}"></script>\n`).join(''));
 
         return content;
     }

--- a/src/gltfPreviewDocumentContentProvider.ts
+++ b/src/gltfPreviewDocumentContentProvider.ts
@@ -117,7 +117,7 @@ export class GltfPreviewDocumentContentProvider implements TextDocumentContentPr
         // Note that with the file: protocol, we must manually specify the UTF-8 charset.
         const content = this._mainHtml.replace('{assets}',
             styles.map(s => `<link rel="stylesheet" href="${this.getFilePath(s)}"></link>\n`).join('') +
-            strings.map(s => `<script id="${s.id}" type="text/plain" charset="UTF-8">${s.text}</script>\n`).join('') +
+            strings.map(s => `<script id="${s.id}" type="text/plain">${s.text}</script>\n`).join('') +
             scripts.map(s => `<script type="text/javascript" charset="UTF-8" src="${this.getFilePath(s)}"></script>\n`).join(''));
 
         return content;


### PR DESCRIPTION
Best guess here is that the `<meta>` tag at the top of the preview HTML file, which is intended to supply an abbreviated HTTP header indicating UTF-8 charset, is not used by the `<script>` tags, presumably because the `<script>` tags are using the `file` scheme and not HTTP.

Manually specifying UTF-8 in the script tags themselves appears to fix the problem.  There's a longer thread on all this in AnalyticalGraphicsInc/cesium#6011.

Separate from all this, a deprecated `taskName` was given a new `label`.