### PR TITLE
Fix busted Cesium animation controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### 2.1.3 - UNRELEASED
+
+* Fixed a broken animation control in the Cesium preview.
+* Fixed some bugs exposed by Project Polly from the Khronos Blender Exporter.
+
 ### 2.1.2 - 2017-12-01
 
 * Fixed file path problems in glTF Preview window for Mac and Linux systems.

--- a/pages/cesiumView.js
+++ b/pages/cesiumView.js
@@ -33,7 +33,7 @@ var CesiumView = function() {
                 anim.animation = undefined;
             } else {
                 anim.animation = model.activeAnimations.add({
-                    name: anim.index,
+                    index: anim.index,
                     loop: Cesium.ModelAnimationLoop.REPEAT
                 });
             }


### PR DESCRIPTION
Fixes #75.

This happened due to an API change that I merged into Cesium in AnalyticalGraphicsInc/cesium#5815 back in early September.  Just recently I took the Cesium update and forgot to make the corresponding change here.