### PR TITLE
Switch to use an encoded path for gltf-dataUri uris.

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,13 +264,13 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.48",
-        "@types/node": "^8.9.5",
-        "eslint": "^4.18.1",
+        "@types/node": "^8.10.0",
+        "eslint": "^4.19.1",
         "eslint-config-cesium": "^3.0.0",
         "eslint-plugin-html": "^4.0.2",
         "mocha": "^4.1.0",
         "typescript": "^2.7.2",
-        "yargs": "^11.0.0"
+        "yargs": "^11.1.0"
     },
     "dependencies": {
         "babylonjs": "^3.2.0-beta.1",
@@ -280,7 +280,7 @@
         "gltf-validator": "2.0.0-dev.1.7",
         "json-source-map": "^0.4.0",
         "sprintf-js": "^1.1.1",
-        "vscode": "^1.1.13",
+        "vscode": "^1.1.14",
         "vscode-languageclient": "^3.5.1"
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "gltf-validator": "2.0.0-dev.1.7",
         "json-source-map": "^0.4.0",
-        "vscode-languageserver": "3.5.0",
+        "vscode-languageserver": "^3.5.1",
         "vscode-uri": "^1.0.1"
     },
     "scripts": {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -438,7 +438,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 let primitive = getFromPath(pathData.jsonMap.data, primitivePath);
                 if (primitive && primitive.extensions && primitive.extensions['KHR_draco_mesh_compression']) {
                     let indicesPath = primitivePath + '/extensions/KHR_draco_mesh_compression/attributes/indices';
-                    let uri = 'gltf-dataUri://' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + indicesPath;
+                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + indicesPath;
                     return makeLocation(null, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
@@ -446,7 +446,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
             }
             else if (part === 'POSITION' || part === 'NORMAL' || part === 'TANGENT'|| part === 'TEXCOORD_0' || part === 'TEXCOORD_1' || part === 'COLOR_0' || part === 'JOINTS_0' || part === 'WEIGHTS_0') {
                 if (inDraco) {
-                    let uri = 'gltf-dataUri://' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + currentPath;
+                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
                     return makeLocation(null, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
@@ -492,7 +492,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 if (!result.uri.startsWith('data:') && !currentPath.startsWith('/images/')) {
                     return makeLocation(null, Url.resolve(textDocumentPosition.textDocument.uri, result.uri));
                 } else {
-                    let uri = 'gltf-dataUri://' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + currentPath;
+                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
                     return makeLocation(null, uri);
                 }
             } else if (part === 'accessors') {
@@ -500,7 +500,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
             } else if (part === 'KHR_draco_mesh_compression') {
                 inDraco = true;
             } else if (inAccessors && !path.includes('bufferView')) {
-                let uri = 'gltf-dataUri://' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + currentPath;
+                let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
                 return makeLocation(null, uri);
             }
         }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -405,6 +405,10 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
         return Location.create(uri, range);
     }
 
+    function makeDataUri(doc: TextDocumentPositionParams, path: string): string {
+        return 'gltf-dataUri://x/' + encodeURIComponent(Uri.parse(doc.textDocument.uri).fsPath) + '#' + path;
+    }
+
     const firstValidIndex = 1; // Because the path has a leading slash.
     let inNodes: boolean = false;
     let inChannels: boolean = false;
@@ -438,7 +442,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 let primitive = getFromPath(pathData.jsonMap.data, primitivePath);
                 if (primitive && primitive.extensions && primitive.extensions['KHR_draco_mesh_compression']) {
                     let indicesPath = primitivePath + '/extensions/KHR_draco_mesh_compression/attributes/indices';
-                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + indicesPath;
+                    let uri = makeDataUri(textDocumentPosition, indicesPath);
                     return makeLocation(null, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
@@ -446,7 +450,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
             }
             else if (part === 'POSITION' || part === 'NORMAL' || part === 'TANGENT'|| part === 'TEXCOORD_0' || part === 'TEXCOORD_1' || part === 'COLOR_0' || part === 'JOINTS_0' || part === 'WEIGHTS_0') {
                 if (inDraco) {
-                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
+                    let uri = makeDataUri(textDocumentPosition, currentPath);
                     return makeLocation(null, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
@@ -492,7 +496,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 if (!result.uri.startsWith('data:') && !currentPath.startsWith('/images/')) {
                     return makeLocation(null, Url.resolve(textDocumentPosition.textDocument.uri, result.uri));
                 } else {
-                    let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
+                    let uri = makeDataUri(textDocumentPosition, currentPath);
                     return makeLocation(null, uri);
                 }
             } else if (part === 'accessors') {
@@ -500,7 +504,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
             } else if (part === 'KHR_draco_mesh_compression') {
                 inDraco = true;
             } else if (inAccessors && !path.includes('bufferView')) {
-                let uri = 'gltf-dataUri:///' + encodeURIComponent(Uri.parse(textDocumentPosition.textDocument.uri).fsPath) + '#' + currentPath;
+                let uri = makeDataUri(textDocumentPosition, currentPath);
                 return makeLocation(null, uri);
             }
         }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -406,7 +406,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
     }
 
     function makeDataUri(doc: TextDocumentPositionParams, path: string): string {
-        return 'gltf-dataUri://x/' + encodeURIComponent(Uri.parse(doc.textDocument.uri).fsPath) + '#' + path;
+        return 'gltf-dataUri:' + path + '#' + encodeURIComponent(Uri.parse(doc.textDocument.uri).fsPath);
     }
 
     const firstValidIndex = 1; // Because the path has a leading slash.

--- a/src/dataUriTextDocumentContentProvider.ts
+++ b/src/dataUriTextDocumentContentProvider.ts
@@ -109,7 +109,7 @@ export class DataUriTextDocumentContentProvider implements TextDocumentContentPr
     private _onDidChange = new EventEmitter<Uri>();
     private _context: ExtensionContext;
 
-    public UriPrefix = 'gltf-dataUri:///';
+    public UriPrefix = 'gltf-dataUri://x/';
 
     constructor(context: ExtensionContext) {
         this._context = context;

--- a/src/dataUriTextDocumentContentProvider.ts
+++ b/src/dataUriTextDocumentContentProvider.ts
@@ -109,7 +109,7 @@ export class DataUriTextDocumentContentProvider implements TextDocumentContentPr
     private _onDidChange = new EventEmitter<Uri>();
     private _context: ExtensionContext;
 
-    public UriPrefix = 'gltf-dataUri://';
+    public UriPrefix = 'gltf-dataUri:///';
 
     constructor(context: ExtensionContext) {
         this._context = context;
@@ -139,11 +139,16 @@ export class DataUriTextDocumentContentProvider implements TextDocumentContentPr
     }
 
     public async provideTextDocumentContent(uri: Uri): Promise<string> {
-        let fileName = decodeURIComponent(uri.authority);
+        let encodedFilename = uri.path;
+        if (encodedFilename.length > 0) {
+            encodedFilename = encodedFilename.substr(1);  // trim the initial '/'
+        }
+
+        let fileName = decodeURIComponent(encodedFilename);
         const query = querystring.parse<QueryDataUri>(uri.query);
         query.viewColumn = query.viewColumn || ViewColumn.Active.toString();
         let glTFContent: string;
-        const document = vscode.workspace.textDocuments.find(e => e.fileName.toLowerCase() === fileName.toLowerCase());
+        const document = vscode.workspace.textDocuments.find(e => e.uri.scheme === 'file' && e.fileName.toLowerCase() === fileName.toLowerCase());
         if (document) {
             fileName = document.fileName;
             glTFContent = document.getText();
@@ -151,7 +156,7 @@ export class DataUriTextDocumentContentProvider implements TextDocumentContentPr
             glTFContent = fs.readFileSync(fileName, 'UTF-8');
         }
         const glTF = JSON.parse(glTFContent);
-        let jsonPointer = uri.path;
+        let jsonPointer = uri.fragment;
         if (this.isShader(jsonPointer) && jsonPointer.endsWith('.glsl')) {
             jsonPointer = jsonPointer.substring(0, jsonPointer.length - 5);
         }
@@ -176,7 +181,7 @@ export class DataUriTextDocumentContentProvider implements TextDocumentContentPr
                         if (vscode.window.activeTextEditor == null || vscode.window.activeTextEditor.document != document || query.viewColumn != ViewColumn.Active.toString()) {
                             vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                         }
-                        let previewUri: Uri = Uri.parse(this.UriPrefix + uri.authority + uri.path + '?previewHtml=true');
+                        let previewUri: Uri = Uri.parse(this.UriPrefix + encodeURIComponent(encodedFilename) + '?previewHtml=true' + '#' + uri.fragment);
                         await vscode.commands.executeCommand('vscode.previewHtml', previewUri, parseInt(query.viewColumn));
                         return '';
                     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,8 +154,6 @@ export function activate(context: vscode.ExtensionContext) {
         const isImage = dataPreviewProvider.isImage(jsonPointer);
         const isAccessor = dataPreviewProvider.isAccessor(jsonPointer);
 
-        let previewUri;
-
         if (!isImage && !isShader && !isAccessor) {
             vscode.window.showErrorMessage('This feature currently works only with accessors, images, and shaders.');
             console.log('gltf-vscode: No preview for: ' + jsonPointer);
@@ -178,9 +176,8 @@ export function activate(context: vscode.ExtensionContext) {
                 jsonPointer += '.glsl';
             }
 
-            previewUri = Uri.parse(dataPreviewProvider.UriPrefix +
-                encodeURIComponent(vscode.window.activeTextEditor.document.fileName) +
-                '?viewColumn=' + ViewColumn.Two + '#' + jsonPointer);
+            const previewUri = Uri.parse(dataPreviewProvider.UriPrefix + jsonPointer + '?viewColumn=' + ViewColumn.Two + '#' +
+                encodeURIComponent(vscode.window.activeTextEditor.document.fileName));
             await vscode.commands.executeCommand('vscode.open', previewUri, ViewColumn.Two);
             dataPreviewProvider.update(previewUri);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,7 +180,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             previewUri = Uri.parse(dataPreviewProvider.UriPrefix +
                 encodeURIComponent(vscode.window.activeTextEditor.document.fileName) +
-                jsonPointer + '?viewColumn=' + ViewColumn.Two);
+                '?viewColumn=' + ViewColumn.Two + '#' + jsonPointer);
             await vscode.commands.executeCommand('vscode.open', previewUri, ViewColumn.Two);
             dataPreviewProvider.update(previewUri);
         }


### PR DESCRIPTION
A uri.authority part can be legally lowercased and then will no longer
match actual filenames on case sensitive platforms.
Also update client and server npm packages because they are initially mismatched (breaks on clean clones).