### PR TITLE
Add animation controls to Babylon preview.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.1.9 - UNRELEASED
 
 * Fixed an issue with previewing data from a temporary document on a case-sensitive file system. [#95](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/95)
-* Added animation controls to Babylon preview UI.
+* Added animation controls to Babylon preview UI. [#97](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/97)
 
 ### 2.1.8 - 2018-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.1.9 - UNRELEASED
 
 * Fixed an issue with previewing data from a temporary document on a case-sensitive file system. [#95](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/95)
+* Added animation controls to Babylon preview UI.
 
 ### 2.1.8 - 2018-03-22
 

--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -66,7 +66,7 @@ window.BabylonView = function() {
 
         BABYLON.SceneLoader.OnPluginActivatedObservable.add(function (plugin) {
             plugin.animationStartMode = BABYLON.GLTFLoaderAnimationStartMode.NONE;
-        });
+        }, undefined, undefined, undefined, true);
 
         var defaultBabylonReflection = document.getElementById('defaultBabylonReflection').textContent;
         var rootPath = document.getElementById('gltfRootPath').textContent;

--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -1,4 +1,4 @@
-/*global BABYLON,mainViewModel*/
+/*global BABYLON,mainViewModel,ko*/
 (function() {
     'use strict';
 
@@ -23,6 +23,7 @@ window.BabylonView = function() {
             backgroundSubscription.dispose();
             backgroundSubscription = undefined;
         }
+        mainViewModel.animations([]);
         enabled = false;
         window.removeEventListener('resize', onWindowResize);
         engine.stopRenderLoop(render);
@@ -38,6 +39,19 @@ window.BabylonView = function() {
         }
 
         engine.resize();
+    }
+
+    function subscribeToAnimUI(anim) {
+        anim.active.subscribe(function(newValue) {
+            mainViewModel.anyAnimChanged();
+            var animGroup = anim.animationGroup;
+            if (!newValue) {
+                animGroup.pause();
+                animGroup.reset();
+            } else {
+                animGroup.restart();
+            }
+        });
     }
 
     this.startPreview = function() {
@@ -59,6 +73,30 @@ window.BabylonView = function() {
             scene.createDefaultCameraOrLight(true);
             scene.activeCamera.attachControl(canvas);
             scene.activeCamera.wheelDeltaPercentage = 0.005;
+
+            // Hook up animations to the UI.
+            let numAnimations = scene.animationGroups.length;
+            let koAnimations = [];
+            for (let i = 0; i < numAnimations; ++i) {
+                let animGroup = scene.animationGroups[i];
+                if (!animGroup.isStarted) {
+                    animGroup.start(true);
+                }
+                animGroup.pause();
+                animGroup.reset();
+
+                var anim = {
+                    index: i,
+                    name: animGroup.name || i,
+                    active: ko.observable(false),
+                    animationGroup: animGroup
+                };
+                subscribeToAnimUI(anim);
+                koAnimations.push(anim);
+            }
+            mainViewModel.animations(koAnimations);
+            mainViewModel.anyAnimChanged();
+
             // glTF assets use a +Z forward convention while the default camera faces +Z.
             // Rotate the camera to look at the front of the asset.
             scene.activeCamera.alpha += Math.PI;

--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -46,10 +46,10 @@ window.BabylonView = function() {
             mainViewModel.anyAnimChanged();
             var animGroup = anim.animationGroup;
             if (!newValue) {
-                animGroup.pause();
                 animGroup.reset();
+                animGroup.stop();
             } else {
-                animGroup.restart();
+                animGroup.start(true);
             }
         });
     }
@@ -63,6 +63,10 @@ window.BabylonView = function() {
         engine.enableOfflineSupport = false;
         scene = new BABYLON.Scene(engine);
         scene.useRightHandedSystem = true; // This is needed for correct glTF normal maps.
+
+        BABYLON.SceneLoader.OnPluginActivatedObservable.add(function (plugin) {
+            plugin.animationStartMode = BABYLON.GLTFLoaderAnimationStartMode.NONE;
+        });
 
         var defaultBabylonReflection = document.getElementById('defaultBabylonReflection').textContent;
         var rootPath = document.getElementById('gltfRootPath').textContent;
@@ -79,13 +83,7 @@ window.BabylonView = function() {
             let koAnimations = [];
             for (let i = 0; i < numAnimations; ++i) {
                 let animGroup = scene.animationGroups[i];
-                if (!animGroup.isStarted) {
-                    animGroup.start(true);
-                }
-                animGroup.pause();
-                animGroup.reset();
-
-                var anim = {
+                let anim = {
                     index: i,
                     name: animGroup.name || i,
                     active: ko.observable(false),


### PR DESCRIPTION
Fixes #87.

@bghgary This is the strategy used here:

* At startup, I iterate the list of `scene.animationGroups` to collect the names, I start any that aren't started (because I don't have a reference to the glTF loader to set the "all" flag), and I immediately `pause()` and `reset()` all the started animations (so they are "stopped" from a user point of view, but Babylon just thinks they're paused).

* When the user toggles the UI, I call `animationGroup.pause(); animationGroup.reset();` or `animationGroup.restart();` to get the animation paused or restarted.

In my experiments, I was never able to restart an animation after calling `stop` on it.  So, I get them all into a started-but-paused state and just un-pause them or re-pause and reset them when the UI changes.