### PR TITLE
fixed gammasettings in threejs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to gltf-
    * [Howard Wolosky](https://github.com/HowardWolosky)
    * [David Catuhe](https://github.com/deltakosh)
    * [Jamie Marconi](https://github.com/najadojo)
+   * [Johan Bowald](https://github.com/bowald)

--- a/pages/threeView.js
+++ b/pages/threeView.js
@@ -78,6 +78,7 @@ window.ThreeView = function() {
         renderer.setClearColor(0x222222);
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.gammaOutput = true;
 
         if (sceneInfo.shadows) {
             renderer.shadowMap.enabled = true;


### PR DESCRIPTION
ThreeJs defaults to render in linear. When **renderer.gammaOutput** is set, output is in sRGB.

See [ThreeJs issue #11110](https://github.com/mrdoob/three.js/issues/11110) for more info. 

![pr-summary](https://user-images.githubusercontent.com/5426333/38270316-4a6588e6-3783-11e8-9a17-e87e145c7916.jpg)
