### PR TITLE
Fix Cesium logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update Babylon to 3.2.0-rc.1
 * Update ThreeJS to r92
 * Update Cesium to master@7307f816c1e4ed (post v1.44)
+* Fix Cesium logo. [#105](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/105)
 
 ### 2.1.11 - 2018-04-04
 

--- a/pages/cesiumView.js
+++ b/pages/cesiumView.js
@@ -7,6 +7,7 @@ window.CesiumView = function() {
     var enabled = false;
     var scene = null;
     var canvas = null;
+    var fixLogo = true;
 
     // The model is placed at the North Pole so the star map is completely right-side up.
     // But the pole doesn't get much sunlight.  STK says 23.444 degrees solar elevation
@@ -82,6 +83,14 @@ window.CesiumView = function() {
         var currentTime = clock.tick();
         scene.render(currentTime);
         Cesium.requestAnimationFrame(startRenderLoop);
+
+        if (fixLogo) {
+            fixLogo = false;
+            const element = document.querySelector('.cesium-credit-logoContainer img');
+            if (element) {
+                element.src = Cesium.buildModuleUrl('Assets/Images/cesium_credit.png');
+            }
+        }
     }
 
     function setCamera(scene, model) {


### PR DESCRIPTION
Fixes #105.

Not sure why it was broken.  The `Credit.html` thing seems to be set correctly, but the constructed element has a blank image source, in spite of the correctly populated `html` string value.  The base URL is the `gltf-preview` protocol and the source URL is the `file` protocol, so maybe there's some kind of cross-origin security violation involved.  Not sure.  Anyway I fixed it with this terrible, hacky hack.