### PR TITLE
AGI metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.1.16 - UNRELEASED
+
+* Add support for two `AGI_` vendor extension schemas.
+
 ### 2.1.15 - 2018-09-10
 
 * Added support for JSON schema validation of various glTF 2.0 extensions. [#119](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/119)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Certain glTF 2.0 extensions are supported by JSON schema validation in VSCode.  
 * `KHR_materials_unlit`
 * `KHR_techniques_webgl` (Draft)
 * `KHR_texture_transform`
+* `AGI_articulations`
+* `AGI_stk_metadata`
 
 Support for additional extensions can be requested by filing an issue or pull request to [the GitHub repository](https://github.com/AnalyticalGraphicsInc/gltf-vscode).
 

--- a/schemas/gltf-2.0/extensions/AGI_articulations/articulation.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_articulations/articulation.schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "Articulation",
+    "type" : "object",
+    "description" : "A model articulation definition.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "name" : {
+            "type" : "string",
+            "pattern" : "^[^\\s]+$",
+            "description" : "The name of this articulation.  The articulation name must be unique within this model.  Articulation names may not contain spaces.",
+            "minLength" : 1
+        },
+        "stages" : {
+            "type" : "array",
+            "description" : "An array of stages, each of which defines a degree of freedom of movement.",
+            "items" : {
+                "$ref" : "articulation.stage.schema.json"
+            },
+            "minItems" : 1
+        },
+        "pointingVector" : {
+            "type" : "array",
+            "description" : "The local forward vector for the associated node, for the purpose of pointing at a target or other object.",
+            "items" : {
+                "type" : "number"
+            },
+            "minItems" : 3,
+            "maxItems" : 3
+        },
+        "extensions" : {},
+        "extras" : {}
+    },
+    "required" : [
+        "name",
+        "stages"
+    ]
+}

--- a/schemas/gltf-2.0/extensions/AGI_articulations/articulation.stage.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_articulations/articulation.stage.schema.json
@@ -1,0 +1,108 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "Articulation Stage",
+    "type" : "object",
+    "description" : "One stage of a model articulation definition.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "name" : {
+            "type" : "string",
+            "pattern" : "^[^\\s]+$",
+            "description" : "The name of this articulation stage.  The articulation stage name must be unique only within the containing articulation.  Articulation Stage names may not contain spaces.",
+            "minLength" : 1
+        },
+        "type" : {
+            "description" : "The type of motion applied by this articulation stage.",
+            "anyOf" : [
+                {
+                    "enum" : [
+                        "xTranslate"
+                    ],
+                    "description" : "The stage value is a translation along the node's X axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "yTranslate"
+                    ],
+                    "description" : "The stage value is a translation along the node's Y axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "zTranslate"
+                    ],
+                    "description" : "The stage value is a translation along the node's Z axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "xRotate"
+                    ],
+                    "description" : "The stage value is a counter-clockwise rotation in degrees about the node's +X axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "yRotate"
+                    ],
+                    "description" : "The stage value is a counter-clockwise rotation in degrees about the node's +Y axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "zRotate"
+                    ],
+                    "description" : "The stage value is a counter-clockwise rotation in degrees about the node's +Z axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "xScale"
+                    ],
+                    "description" : "The stage value is a scaling factor to multiply along the node's X axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "yScale"
+                    ],
+                    "description" : "The stage value is a scaling factor to multiply along the node's Y axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "zScale"
+                    ],
+                    "description" : "The stage value is a scaling factor to multiply along the node's Z axis. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "enum" : [
+                        "uniformScale"
+                    ],
+                    "description" : "The stage value is uniform scaling factor to apply to the node. - The type of motion applied by this articulation stage."
+                },
+                {
+                    "type" : "string"
+                }
+            ]
+        },
+        "minimumValue" : {
+            "type" : "number",
+            "description" : "The minimum value for the range of motion of this articulation stage."
+        },
+        "maximumValue" : {
+            "type" : "number",
+            "description" : "The maximum value for the range of motion of this articulation stage."
+        },
+        "initialValue" : {
+            "type" : "number",
+            "description" : "The initial value for this articulation stage."
+        },
+        "extensions" : {},
+        "extras" : {}
+    },
+    "required" : [
+        "name",
+        "type",
+        "minimumValue",
+        "maximumValue",
+        "initialValue"
+    ]
+}

--- a/schemas/gltf-2.0/extensions/AGI_articulations/gltf.AGI_articulations.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_articulations/gltf.AGI_articulations.schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "AGI_articulations glTF extension",
+    "type" : "object",
+    "description" : "glTF Extension that defines metadata for applying external analysis or effects to a model.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "articulations" : {
+            "type" : "array",
+            "description" : "An array of articulations.  An articulation indicates a named range of motion available to one or more nodes within the model.",
+            "items" : {
+                "$ref" : "articulation.schema.json"
+            },
+            "minItems" : 1,
+            "short_description" : "An array of articulations."
+        },
+        "extensions" : {},
+        "extras" : {}
+    }
+}

--- a/schemas/gltf-2.0/extensions/AGI_articulations/node.AGI_articulations.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_articulations/node.AGI_articulations.schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "AGI_articulations glTF Node extension",
+    "type" : "object",
+    "description" : "glTF Extension for an individual node in a glTF model, to associate it with the model's root AGI_articulations object.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "isAttachPoint" : {
+            "type" : "boolean",
+            "description" : "Set to true to indicate that this node's origin and orientation act as an attach point for external objects, analysis, or effects."
+        },
+        "articulationName" : {
+            "type" : "string",
+            "pattern" : "^[^\\s]+$",
+            "description" : "The name of an Articulation that applies to this node.  Articulations are defined in the glTF root extension.  A single articulation may apply to more than one node, and its stage values set the transform for all assigned nodes simultaneously.",
+            "short_description" : "The name of an Articulation that applies to this node."
+        },
+        "extensions" : {},
+        "extras" : {}
+    }
+}

--- a/schemas/gltf-2.0/extensions/AGI_stk_metadata/gltf.AGI_stk_metadata.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_stk_metadata/gltf.AGI_stk_metadata.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "AGI_stk_metadata glTF extension",
+    "type" : "object",
+    "description" : "glTF Extension that defines metadata for use with STK (Systems Tool Kit).",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "solarPanelGroups" : {
+            "type" : "array",
+            "description" : "An array of solar panel groups.",
+            "items" : {
+                "$ref" : "solarPanelGroup.schema.json"
+            },
+            "minItems" : 1
+        },
+        "extensions" : {},
+        "extras" : {}
+    }
+}

--- a/schemas/gltf-2.0/extensions/AGI_stk_metadata/node.AGI_stk_metadata.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_stk_metadata/node.AGI_stk_metadata.schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "AGI_stk_metadata glTF Node extension",
+    "type" : "object",
+    "description" : "glTF Extension for an individual node in a glTF model, to associate it with the model's root AGI_stk_metadata object.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "solarPanelGroupName" : {
+            "type" : "string",
+            "pattern" : "^[^\\s]+$",
+            "description" : "The name of a Solar Panel Group that includes this node.  Solar Panel Groups are defined in the glTF root extension.",
+            "short_description" : "The name of a Solar Panel Group that includes this node."
+        },
+        "noObscuration" : {
+            "type" : "boolean",
+            "description" : "Set to true to indicate that this node's geometry does not obscure any sensors' view in the STK Sensor Obscuration tool."
+        },
+        "extensions" : {},
+        "extras" : {}
+    }
+}

--- a/schemas/gltf-2.0/extensions/AGI_stk_metadata/solarPanelGroup.schema.json
+++ b/schemas/gltf-2.0/extensions/AGI_stk_metadata/solarPanelGroup.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "Solar Panel Group",
+    "type" : "object",
+    "description" : "A solar panel group definition.",
+    "allOf" : [
+        {
+            "$ref" : "../../glTFProperty.schema.json"
+        }
+    ],
+    "properties" : {
+        "name" : {
+            "type" : "string",
+            "pattern" : "^[^\\s]+$",
+            "description" : "The name of this solar panel group.  The group name must be unique within this model, and may not contain spaces.",
+            "minLength" : 1
+        },
+        "efficiency" : {
+            "type" : "number",
+            "description" : "The percentage, from 0.0 to 100.0, of how efficiently the solar cells convert solar to electrical energy.",
+            "minimum" : 0,
+            "maximum" : 100
+        },
+        "extensions" : {},
+        "extras" : {}
+    },
+    "required" : [
+        "name",
+        "efficiency"
+    ]
+}

--- a/schemas/gltf-2.0/glTF.schema.json
+++ b/schemas/gltf-2.0/glTF.schema.json
@@ -164,6 +164,20 @@
                             "$ref" : "extensions/KHR_techniques_webgl/glTF.KHR_techniques_webgl.schema.json"
                         }
                     ]
+                },
+                "AGI_articulations" : {
+                    "allOf" : [
+                        {
+                            "$ref" : "extensions/AGI_articulations/gltf.AGI_articulations.schema.json"
+                        }
+                    ]
+                },
+                "AGI_stk_metadata" : {
+                    "allOf" : [
+                        {
+                            "$ref" : "extensions/AGI_stk_metadata/gltf.AGI_stk_metadata.schema.json"
+                        }
+                    ]
                 }
             }
         },

--- a/schemas/gltf-2.0/node.schema.json
+++ b/schemas/gltf-2.0/node.schema.json
@@ -125,7 +125,24 @@
             }
         },
         "name" : {},
-        "extensions" : {},
+        "extensions" : {
+            "properties" : {
+                "AGI_articulations" : {
+                    "allOf" : [
+                        {
+                            "$ref" : "extensions/AGI_articulations/node.AGI_articulations.schema.json"
+                        }
+                    ]
+                },
+                "AGI_stk_metadata" : {
+                    "allOf" : [
+                        {
+                            "$ref" : "extensions/AGI_stk_metadata/node.AGI_stk_metadata.schema.json"
+                        }
+                    ]
+                }
+            }
+        },
         "extras" : {}
     },
     "dependencies" : {

--- a/util/extensionMap2.0.json
+++ b/util/extensionMap2.0.json
@@ -2,7 +2,9 @@
     "glTF": {
         "title": "Root Extensions",
         "extensions": {
-            "KHR_techniques_webgl": "glTF.KHR_techniques_webgl.schema.json"
+            "KHR_techniques_webgl": "glTF.KHR_techniques_webgl.schema.json",
+            "AGI_articulations": "gltf.AGI_articulations.schema.json",
+            "AGI_stk_metadata": "gltf.AGI_stk_metadata.schema.json"
         }
     },
     "material": {
@@ -16,6 +18,13 @@
         "title": "Mesh Primitive Extensions",
         "extensions": {
             "KHR_draco_mesh_compression": "node.KHR_draco_mesh_compression.schema.json"
+        }
+    },
+    "node": {
+        "title": "Node Extensions",
+        "extensions": {
+            "AGI_articulations": "node.AGI_articulations.schema.json",
+            "AGI_stk_metadata": "node.AGI_stk_metadata.schema.json"
         }
     },
     "textureInfo": {

--- a/util/importAll.sh
+++ b/util/importAll.sh
@@ -15,3 +15,7 @@ echo "~~~ KHR_techniques_webgl ~~~"
 ./importSchema.js -i ../../glTF/extensions/2.0/Khronos/KHR_techniques_webgl/schema -o ../schemas/gltf-2.0/extensions/KHR_techniques_webgl -s ../../
 echo "~~~ KHR_texture_transform ~~~"
 ./importSchema.js -i ../../glTF/extensions/2.0/Khronos/KHR_texture_transform/schema -o ../schemas/gltf-2.0/extensions/KHR_texture_transform -s ../../
+echo "~~~ AGI_articulations ~~~"
+./importSchema.js -i ../../glTF/extensions/2.0/Vendor/AGI_articulations/schema -o ../schemas/gltf-2.0/extensions/AGI_articulations -s ../../
+echo "~~~ AGI_stk_metadata ~~~"
+./importSchema.js -i ../../glTF/extensions/2.0/Vendor/AGI_stk_metadata/schema -o ../schemas/gltf-2.0/extensions/AGI_stk_metadata -s ../../


### PR DESCRIPTION
This adds two `AGI_` vendor extension schemas to the existing glTF extension schema validation.

Other vendors are welcome to add additional extension schemas here too.  See commit 76d3585 for an example of how the import schema script was edited to pull in these two new schemas.  Or, just write up an issue.

For more information, see the [Extensions section](https://github.com/AnalyticalGraphicsInc/gltf-vscode/tree/master/util#extensions) of `util/README.md`.