### PR TITLE
Fixed an issue with default model orientation in Cesium.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.1.18 - UNRELEASED
 
 * Fixed schema bug in `EXT_lights_image_based`.  [KhronosGroup/glTF#1482](https://github.com/KhronosGroup/glTF/issues/1482)
+* Fixed an issue with model orientation in the Cesium preview. [#126](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/126)
 
 ### 2.1.17 - 2018-11-08
 

--- a/pages/cesiumView.js
+++ b/pages/cesiumView.js
@@ -114,6 +114,7 @@ window.CesiumView = function() {
         var model = scene.primitives.add(new Cesium.Model({
             gltf: gltfContent,
             basePath: gltfRootPath,
+            forwardAxis: Cesium.Axis.X,
             scale: 100  // Increasing the scale allows the camera to get much closer to small models.
         }));
 
@@ -126,6 +127,7 @@ window.CesiumView = function() {
         var model = scene.primitives.add(Cesium.Model.fromGltf({
             url: gltfRootPath + gltfFileName,
             basePath: gltfRootPath,
+            forwardAxis: Cesium.Axis.X,
             scale: 100
         }));
 


### PR DESCRIPTION
Cesium's internal forward axis has always been `+X`, but glTF uses `+Z`.  Recently Cesium gained more logic for trying to automatically detect glTF 1.0 vs 2.0 and adapt the forward axis accordingly.  But the Cesuim preview window here was already configured for the previous +X system, so, the auto-detect is turned off for this project.

The Babylon and ThreeJS previews are not affected.