### PR TITLE
Allow error messages to append to previous errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed schema bug in `EXT_lights_image_based`.  [KhronosGroup/glTF#1482](https://github.com/KhronosGroup/glTF/issues/1482)
 * Fixed an issue with model orientation in the Cesium preview. [#126](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/126)
+* Fixed an issue where a generic error message could hide a more specific message. [#127](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/127)
 
 ### 2.1.17 - 2018-11-08
 

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -125,6 +125,9 @@ function initPreview()
         if (error && error.message) {
             message = error.message;
         }
+        if (mainViewModel.errorText()) {
+            message = mainViewModel.errorText() + '\n\n' + message;
+        }
         mainViewModel.errorText(message);
     });
 


### PR DESCRIPTION
This fixes an issue where a Cesium error was being hidden behind a less useful message.