### PR TITLE
Put some simple guards around tree expansion.

### DIFF
--- a/src/gltfOutline.ts
+++ b/src/gltfOutline.ts
@@ -108,10 +108,10 @@ export class GltfOutline implements vscode.TreeDataProvider<GltfNode> {
 
     private fillSelectedList(): void {
         this.selectedList.clear();
-        if (vscode.workspace.getConfiguration('glTF').get('expandOutlineWithSelection')) {
+        if (this.tree && vscode.workspace.getConfiguration('glTF').get('expandOutlineWithSelection')) {
             for (let selection of this.editor.selections) {
                 this.walkTree(this.tree, (node: GltfNode) => {
-                    if (node.range.contains(selection)) {
+                    if (node.range && node.range.contains(selection)) {
                         do {
                             this.selectedList.add(node);
                             node = node.parent;


### PR DESCRIPTION
For #138.

Added some simple checks around where things were crashing when `glTF.expandOutlineWithSelection` is turned on.

Tree functionality with this setting is restored, and the correct node will auto-expand when a new tree is constructed from scratch (for example, when launching VSCode).  But once the tree exists, changing the selection does not expand additional nodes.

So, this is only a partial fix.