### PR TITLE
Avoid setting the ThreeJS environment map on unlit materials.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.2.2 - UNRELEASED
+
+* Fixed a bug with `KHR_materials_unlit` being displayed with a reflection map in the ThreeJS preview window. [#143](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/143)
+
 ### 2.2.0 and 2.2.1 - 2018-12-18
 
 * Added BabylonJS Inspector for visual glTF debugging. [#129](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/129)

--- a/pages/threeView.js
+++ b/pages/threeView.js
@@ -131,10 +131,15 @@ window.ThreeView = function() {
             ]);
             envMap.format = THREE.RGBFormat;
             object.traverse(function(node) {
-                // The last part of this guard uses MeshBasicMaterial to look for KHR_materials_unlit.
-                if (node.material && 'envMap' in node.material && node.material.type !== 'MeshBasicMaterial') {
-                    node.material.envMap = envMap;
-                    node.material.needsUpdate = true;
+                if (node.isMesh) {
+                    const materials = Array.isArray(node.material) ? node.material : [node.material];
+                    materials.forEach((material) => {
+                        // MeshBasicMaterial means that KHR_materials_unlit is set, so reflections are not needed.
+                        if ('envMap' in material && !material.isMeshBasicMaterial) {
+                            material.envMap = envMap;
+                            material.needsUpdate = true;
+                        }
+                    });
                 }
             });
 

--- a/pages/threeView.js
+++ b/pages/threeView.js
@@ -131,7 +131,8 @@ window.ThreeView = function() {
             ]);
             envMap.format = THREE.RGBFormat;
             object.traverse(function(node) {
-                if (node.material && 'envMap' in node.material) {
+                // The last part of this guard uses MeshBasicMaterial to look for KHR_materials_unlit.
+                if (node.material && 'envMap' in node.material && node.material.type !== 'MeshBasicMaterial') {
                     node.material.envMap = envMap;
                     node.material.needsUpdate = true;
                 }


### PR DESCRIPTION
This introduces a new check, `node.material.type !== 'MeshBasicMaterial'`, to avoid setting the environment map in ThreeJS on `KHR_materials_unlit` materials.

@donmccurdy I'm not sure if this is the correct way to fix this.  I'm making assumptions about current ThreeJS implementation details remaining permanent, namely that `MeshBasicMaterial` is synonymous with `KHR_materials_unlit`.  Looks like your viewer is [doing the opposite](https://github.com/donmccurdy/three-gltf-viewer/blob/5998675b6e5375bc17e851387cbcb34ededf3991/src/viewer.js#L402) but making similar assumptions based on material type.

I noticed that `MeshBasicMaterial` does have some options for controlling reflectivity or how the env map is combined with the material.  I wonder if `GltfLoader` could/should initialize something to render the env map inert for unlit materials.

Fixes #143.