### PR TITLE
Add support to copy inspect data to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "icon": "images/gltf.png",
     "engines": {
-        "vscode": "^1.25.0"
+        "vscode": "^1.30.0"
     },
     "categories": [
         "Formatters",
@@ -177,6 +177,14 @@
             {
                 "command": "gltf.exportAnimation",
                 "title": "glTF: Export animation"
+            },
+            {
+                "command": "gltfInspectData.copyAll",
+                "title": "Copy All"
+            },
+            {
+                "command": "gltfInspectData.copy",
+                "title": "Copy"
             }
         ],
         "keybindings": [
@@ -284,6 +292,18 @@
                 {
                     "command": "gltf.validateFile",
                     "group": "glTF"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "gltfInspectData.copyAll",
+                    "when": "view == gltfInspectData"
+                }
+            ],
+            "view/item/context": [
+                {
+                    "command": "gltfInspectData.copy",
+                    "when": "view == gltfInspectData"
                 }
             ]
         },

--- a/src/gltfInspectData.ts
+++ b/src/gltfInspectData.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as os from 'os';
 import { GltfWindow } from './gltfWindow';
 import { GLTF2 } from './GLTF2';
 import { getFromJsonPointer, getAccessorData, getAccessorElement, AccessorTypeToNumComponents } from './utilities';
@@ -8,7 +9,7 @@ import { GltfPreviewPanel } from './gltfPreview';
 
 enum NodeType {
     Header,
-    DataGroup,
+    Group,
     AccessorScalar,
     AccessorVector,
     AccessorMatrix,
@@ -27,17 +28,18 @@ enum NodeType {
 
 interface Node {
     type: NodeType;
+    label: string;
+    tooltip?: string;
 }
 
-interface DataGroupNode<T extends Node> extends Node {
+interface GroupNode extends Node {
     startIndex: number;
     endIndex: number;
-    nodes: T[];
+    nodes: Node[];
 }
 
 interface AccessorElementNode extends Node {
     index: number;
-    float: boolean;
 }
 
 interface AccessorScalarNode extends AccessorElementNode {
@@ -58,7 +60,7 @@ interface AccessorMatrixRowNode extends AccessorElementNode {
 
 interface VerticesNode extends Node {
     numVertices: number;
-    nodes: DataGroupNode<VertexNode>[] | VertexNode[];
+    nodes: VertexNode[];
 }
 
 interface VertexNode extends Node {
@@ -72,7 +74,7 @@ interface VertexAttributeNode extends Node {
 }
 
 interface TrianglesNode extends Node {
-    nodes: DataGroupNode<TriangleNode>[] | TriangleNode[];
+    nodes: TriangleNode[];
 }
 
 interface TriangleNode extends Node {
@@ -81,7 +83,7 @@ interface TriangleNode extends Node {
 }
 
 interface LinesNode extends Node {
-    nodes: DataGroupNode<LineNode>[] | LineNode[];
+    nodes: LineNode[];
 }
 
 interface LineNode extends Node {
@@ -90,12 +92,16 @@ interface LineNode extends Node {
 }
 
 interface PointsNode extends Node {
-    nodes: DataGroupNode<PointNode>[] | PointNode[];
+    nodes: PointNode[];
 }
 
 interface PointNode extends Node {
     index: number;
     vertex: number;
+}
+
+function isFloatAccessor(accessor: GLTF2.Accessor): boolean {
+    return accessor.componentType === GLTF2.AccessorComponentType.FLOAT || accessor.normalized;
 }
 
 function formatScalar(value: number, float: boolean): string {
@@ -110,55 +116,66 @@ function formatMatrix(rows: { values: number[] }[], float: boolean): string {
     return rows.map(row => formatVector(row.values, float)).join(', ');
 }
 
-function getDataNodes<T extends Node>(count: number, getNode: (index: number) => T): DataGroupNode<T>[] | T[] {
-    const groupNodes: DataGroupNode<T>[] = [];
-    for (let startIndex = 0, endIndex = 0; startIndex < count; startIndex = endIndex + 1) {
-        endIndex = Math.min(startIndex + 100, count) - 1;
-        const nodes: T[] = [];
-        for (let index = startIndex; index <= endIndex; index++) {
-            nodes.push(getNode(index));
-        }
+function groupNodes(nodes: Node[], groupSize: number): Node[] {
+    if (nodes.length < groupSize) {
+        return nodes;
+    }
+
+    const groupNodes = new Array<GroupNode>();
+    for (let startIndex = 0, endIndex = 0; startIndex < nodes.length; startIndex = endIndex) {
+        endIndex = Math.min(startIndex + groupSize, nodes.length);
         groupNodes.push({
-            type: NodeType.DataGroup,
+            type: NodeType.Group,
+            label: `[${startIndex}..${endIndex}]`,
             startIndex: startIndex,
             endIndex: endIndex,
-            nodes: nodes
+            nodes: nodes.slice(startIndex, endIndex)
         });
     }
 
-    return (groupNodes.length === 1 ? groupNodes[0].nodes : groupNodes);
+    return groupNodes;
 }
 
-function getAccessorNodes(fileName: string, gltf: GLTF2.GLTF, accessor: GLTF2.Accessor): DataGroupNode<AccessorElementNode>[] | AccessorElementNode[] {
+function getAccessorNodes(fileName: string, gltf: GLTF2.GLTF, accessor: GLTF2.Accessor): AccessorElementNode[] {
     const data = getAccessorData(fileName, gltf, accessor);
     if (!data) {
         throw new Error('Unable to get accessor data');
     }
 
-    return getDataNodes(accessor.count, index => {
-        return getAccessorElementNode(accessor, data, index);
-    });
+    const nodes = new Array<AccessorElementNode>(accessor.count);
+    for (let index = 0; index < nodes.length; index++) {
+        nodes[index] = getAccessorElementNode(accessor, data, index);
+    }
+
+    return nodes;
 }
 
 function getAccessorElementNode(accessor: GLTF2.Accessor, data: ArrayLike<number>, index: number): AccessorElementNode {
     const numComponents = AccessorTypeToNumComponents[accessor.type];
     const values = getAccessorElement(data, index, numComponents, accessor.componentType, accessor.normalized);
-    const float = accessor.componentType === GLTF2.AccessorComponentType.FLOAT || accessor.normalized;
+    const float = isFloatAccessor(accessor);
 
     switch (accessor.type) {
         case GLTF2.AccessorType.SCALAR: {
+            const label = formatScalar(values[0], float);
+            const tooltip = `${index}: ${label}`;
             return {
                 type: NodeType.AccessorScalar,
+                label: label,
+                tooltip: tooltip,
                 index: index,
-                float: float,
                 value: values[0]
             } as AccessorScalarNode;
         }
         case GLTF2.AccessorType.VEC2:
         case GLTF2.AccessorType.VEC3:
         case GLTF2.AccessorType.VEC4: {
+            const label = formatVector(values, isFloatAccessor(accessor));
+            const tooltip = `${index}: ${label}`;
             return {
                 type: NodeType.AccessorVector,
+                label: label,
+                tooltip: tooltip,
                 index: index,
                 float: float,
                 values: values
@@ -170,19 +187,25 @@ function getAccessorElementNode(accessor: GLTF2.Accessor, data: ArrayLike<number
             const size = Math.sqrt(numComponents);
             const rows: AccessorMatrixRowNode[] = [];
             for (let rowIndex = 0; rowIndex < size; rowIndex++) {
+                const rowLabel = formatVector(values, float);
+                const rowTooltip = `${rowIndex}: ${rowLabel}`;
                 const start = rowIndex * size;
                 const end = start + size;
                 rows.push({
                     type: NodeType.AccessorMatrixRow,
+                    label: rowLabel,
+                    tooltip: rowTooltip,
                     index: rowIndex,
-                    float: float,
                     values: values.slice(start, end)
                 });
             }
+            const label = formatMatrix(rows, float);
+            const tooltip = `${index}: ${label}`;
             return {
                 type: NodeType.AccessorMatrix,
+                label: label,
+                tooltip: tooltip,
                 index: index,
-                float: float,
                 rows: rows
             } as AccessorMatrixNode;
         }
@@ -220,63 +243,69 @@ function getVerticesNode(fileName: string, gltf: GLTF2.GLTF, attributes: { [name
         };
     }
 
-    const nodes = getDataNodes(numVertices, index => {
+    const nodes = new Array<VertexNode>(numVertices);
+    for (let index = 0; index < nodes.length; index++) {
         const attributeNodes: VertexAttributeNode[] = [];
         for (const attribute in attributes) {
             const info = accessorInfo[attribute];
+            const values = getAccessorElement(info.data, index, info.numComponents, info.accessor.componentType, info.accessor.normalized);
             attributeNodes.push({
                 type: NodeType.VertexAttribute,
+                label: `${attribute}: ${formatVector(values, isFloatAccessor(info.accessor))}`,
                 name: attribute,
-                values: getAccessorElement(info.data, index, info.numComponents, info.accessor.componentType, info.accessor.normalized)
+                values: values
             });
         }
-        return {
+        nodes[index] = {
             type: NodeType.Vertex,
+            label: `${index}`,
             index: index,
             attributeNodes: attributeNodes
-        } as VertexNode;
-    });
+        };
+    };
 
     return {
         type: NodeType.Vertices,
+        label: 'Vertices',
         numVertices: numVertices,
         nodes: nodes
     };
 }
 
-function getTriangleNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, data: ArrayLike<number> | undefined): DataGroupNode<TriangleNode>[] | TriangleNode[] {
-    const get = data ? i => data[i] : i => i;
+function getTriangleNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, data: ArrayLike<number> | undefined): TriangleNode[] {
+    const get = data ? (i: number) => data[i] : (i: number) => i;
     const length = data ? data.length : numVertices;
     let nodes: TriangleNode[];
+
+    function setNode(index: number, vertices: [number, number, number]): void {
+        nodes[index] = {
+            type: NodeType.Triangle,
+            label: `${formatVector(vertices, false)}`,
+            index: index,
+            vertices: vertices
+        };
+    }
 
     switch (mode) {
         case GLTF2.MeshPrimitiveMode.TRIANGLES: {
             nodes = new Array(length / 3);
             for (let index = 0; index < nodes.length; index++) {
-                nodes[index] = {
-                    type: NodeType.Triangle,
-                    index: index,
-                    vertices: [
-                        get(index * 3),
-                        get(index * 3 + 1),
-                        get(index * 3 + 2)
-                    ]
-                };
+                setNode(index, [
+                    get(index * 3),
+                    get(index * 3 + 1),
+                    get(index * 3 + 2)
+                ]);
             }
             break;
         }
         case GLTF2.MeshPrimitiveMode.TRIANGLE_FAN: {
             nodes = new Array(length - 2);
             for (let index = 0; index < nodes.length; index++) {
-                nodes[index] = {
-                    type: NodeType.Triangle,
-                    index: index,
-                    vertices: [
-                        get(0),
-                        get(index + 1),
-                        get(index + 2)
-                    ]
-                };
+                setNode(index, [
+                    get(0),
+                    get(index + 1),
+                    get(index + 2)
+                ]);
             }
             break;
         }
@@ -284,40 +313,41 @@ function getTriangleNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, da
             nodes = new Array(length - 2);
             for (let index = 0; index < nodes.length; index++) {
                 const flip = (index & 1) === 1;
-                nodes[index] = {
-                    type: NodeType.Triangle,
-                    index: index,
-                    vertices: [
-                        get(flip ? index + 2 : index),
-                        get(index + 1),
-                        get(flip ? index : index + 2)
-                    ]
-                };
+                setNode(index, [
+                    get(flip ? index + 2 : index),
+                    get(index + 1),
+                    get(flip ? index : index + 2)
+                ]);
             }
             break;
         }
     }
 
-    return getDataNodes(nodes.length, index => nodes[index]);
+    return nodes;
 }
 
-function getLineNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, data: ArrayLike<number> | undefined): DataGroupNode<LineNode>[] | LineNode[] {
+function getLineNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, data: ArrayLike<number> | undefined): LineNode[] {
     const get = data ? i => data[i] : i => i;
     const length = data ? data.length : numVertices;
     let nodes: LineNode[];
+
+    function setNode(index: number, vertices: [number, number]): void {
+        nodes[index] = {
+            type: NodeType.Line,
+            label: `${formatVector(vertices, false)}`,
+            index: index,
+            vertices: vertices
+        };
+    }
 
     switch (mode) {
         case GLTF2.MeshPrimitiveMode.LINES: {
             nodes = new Array(length / 2);
             for (let index = 0; index < nodes.length; index++) {
-                nodes[index] = {
-                    type: NodeType.Line,
-                    index: index,
-                    vertices: [
-                        get(index * 2),
-                        get(index * 2 + 1)
-                    ]
-                };
+                setNode(index, [
+                    get(index * 2),
+                    get(index * 2 + 1)
+                ]);
             }
             break;
         }
@@ -325,34 +355,31 @@ function getLineNodes(numVertices: number, mode: GLTF2.MeshPrimitiveMode, data: 
         case GLTF2.MeshPrimitiveMode.LINE_STRIP: {
             nodes = new Array(mode === GLTF2.MeshPrimitiveMode.LINE_LOOP ? length : length - 1);
             for (let index = 0; index < nodes.length; index++) {
-                nodes[index] = {
-                    type: NodeType.Line,
-                    index: index,
-                    vertices: [
-                        get(index),
-                        get((index + 1) % length)
-                    ]
-                };
+                setNode(index, [
+                    get(index),
+                    get((index + 1) % length)
+                ]);
             }
             break;
         }
     }
 
-    return getDataNodes(nodes.length, index => nodes[index]);
+    return nodes;
 }
 
-function getPointNodes(numVertices: number, data: ArrayLike<number> | undefined): DataGroupNode<PointNode>[] | PointNode[] {
+function getPointNodes(numVertices: number, data: ArrayLike<number> | undefined): PointNode[] {
     const get = data ? i => data[i] : i => i;
     const nodes = new Array<PointNode>(data ? data.length : numVertices);
     for (let index = 0; index < nodes.length; index++) {
         nodes[index] = {
             type: NodeType.Point,
+            label: `${index}`,
             index: index,
             vertex: get(index)
         }
     }
 
-    return getDataNodes(nodes.length, index => nodes[index]);
+    return nodes;
 }
 
 function getIndicesNode(fileName: string, gltf: GLTF2.GLTF, numVertices: number, mode: GLTF2.MeshPrimitiveMode | undefined, indices: number | undefined): TrianglesNode | LinesNode | PointsNode {
@@ -368,6 +395,7 @@ function getIndicesNode(fileName: string, gltf: GLTF2.GLTF, numVertices: number,
         case GLTF2.MeshPrimitiveMode.TRIANGLE_STRIP: {
             return {
                 type: NodeType.Triangles,
+                label: 'Triangles',
                 nodes: getTriangleNodes(numVertices, mode, data)
             } as TrianglesNode;
         }
@@ -376,12 +404,14 @@ function getIndicesNode(fileName: string, gltf: GLTF2.GLTF, numVertices: number,
         case GLTF2.MeshPrimitiveMode.LINE_STRIP: {
             return {
                 type: NodeType.Lines,
+                label: 'Lines',
                 nodes: getLineNodes(numVertices, mode, data)
             } as LinesNode;
         }
         case GLTF2.MeshPrimitiveMode.POINTS: {
             return {
                 type: NodeType.Points,
+                label: 'Points',
                 nodes: getPointNodes(numVertices, data)
             } as PointsNode;
         }
@@ -404,7 +434,8 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
     private _treeView: vscode.TreeView<Node>;
     private _fileName: string;
     private _jsonPointer: string;
-    private _roots: Node[];
+    private _headerNode: Node;
+    private _nodes: Node[];
     private _onDidChangeTreeData: vscode.EventEmitter<Node | null> = new vscode.EventEmitter<Node | null>();
 
     constructor(context: vscode.ExtensionContext, gltfWindow: GltfWindow) {
@@ -425,106 +456,43 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
         this._gltfWindow.preview.onDidChangeReadyState(panel => {
             this.updateSelection(panel, this._treeView.selection);
         });
+
+        context.subscriptions.push(vscode.commands.registerCommand('gltfInspectData.copy', (node: Node) => {
+            vscode.env.clipboard.writeText(node.label);
+        }));
+
+        context.subscriptions.push(vscode.commands.registerCommand('gltfInspectData.copyAll', () => {
+            let text = `${this._headerNode.label}${os.EOL}`;
+
+            const traverseNodes = (nodes: Node[], indent: string) => {
+                for (const node of nodes) {
+                    text += `${indent}${node.label}${os.EOL}`;
+                    traverseNodes(this.getChildren(node, Number.MAX_VALUE), `  ${indent}`);
+                }
+            }
+
+            traverseNodes(this._nodes, '');
+
+            vscode.env.clipboard.writeText(text);
+        }));
     }
 
     public readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     public getTreeItem(node: Node): vscode.TreeItem {
-        let treeItem: vscode.TreeItem;
-        switch (node.type) {
-            case NodeType.Header: {
-                treeItem = new vscode.TreeItem(this._jsonPointer, vscode.TreeItemCollapsibleState.None);
-                break;
-            }
-            case NodeType.DataGroup: {
-                const groupNode = node as DataGroupNode<Node>;
-                treeItem = new vscode.TreeItem(`[${groupNode.startIndex}..${groupNode.endIndex}]`, vscode.TreeItemCollapsibleState.Collapsed);
-                break;
-            }
-            case NodeType.AccessorScalar: {
-                const scalarNode = node as AccessorScalarNode;
-                const label = formatScalar(scalarNode.value, scalarNode.float);
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                treeItem.tooltip = `${scalarNode.index}: ${label}`;
-                break;
-            }
-            case NodeType.AccessorVector: {
-                const vectorNode = node as AccessorVectorNode;
-                const label = formatVector(vectorNode.values, vectorNode.float);
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                treeItem.tooltip = `${vectorNode.index}: ${label}`;
-                break;
-            }
-            case NodeType.AccessorMatrix: {
-                const matrixNode = node as AccessorMatrixNode;
-                const label = formatMatrix(matrixNode.rows, matrixNode.float);
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Collapsed);
-                treeItem.tooltip = `${matrixNode.index}: ${label}`;
-                break;
-            }
-            case NodeType.AccessorMatrixRow: {
-                const matrixRowNode = node as AccessorMatrixRowNode;
-                const label = formatVector(matrixRowNode.values, matrixRowNode.float);
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                treeItem.tooltip = `${matrixRowNode.index}: ${label}`;
-                break;
-            }
-            case NodeType.Vertices: {
-                treeItem = new vscode.TreeItem('Vertices', vscode.TreeItemCollapsibleState.Collapsed);
-                break;
-            }
-            case NodeType.Vertex: {
-                const vertexNode = node as VertexNode;
-                treeItem = new vscode.TreeItem(`${vertexNode.index}`, vscode.TreeItemCollapsibleState.Collapsed);
-                // Adding a command so that it does not expand when clicking on the item.
-                // See https://github.com/Microsoft/vscode/issues/34130#issuecomment-398783006.
-                // The actual handling of selection is in onDidSelectionChange to support multiselect.
-                treeItem.command = { title: '', command: 'gltf.noop' }
-                break;
-            }
-            case NodeType.VertexAttribute: {
-                const vertexAttributeNode = node as VertexAttributeNode;
-                const label = `${vertexAttributeNode.name}: ${formatVector(vertexAttributeNode.values, true)}`;
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                break;
-            }
-            case NodeType.Triangles: {
-                treeItem = new vscode.TreeItem('Triangles', vscode.TreeItemCollapsibleState.Collapsed);
-                break;
-            }
-            case NodeType.Triangle: {
-                const triangleNode = node as TriangleNode;
-                const label = `${formatVector(triangleNode.vertices, false)}`;
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                break;
-            }
-            case NodeType.Lines: {
-                treeItem = new vscode.TreeItem('Lines', vscode.TreeItemCollapsibleState.Collapsed);
-                break;
-            }
-            case NodeType.Line: {
-                const lineNode = node as LineNode;
-                const label = `${formatVector(lineNode.vertices, false)}`;
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                break;
-            }
-            case NodeType.Points: {
-                treeItem = new vscode.TreeItem('Points', vscode.TreeItemCollapsibleState.Collapsed);
-                break;
-            }
-            case NodeType.Point: {
-                const pointNode = node as PointNode;
-                const label = `${pointNode.index}`;
-                treeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
-                break;
-            }
-            default: {
-                throw new Error('Invalid data node type');
-            }
+        const treeItem = new vscode.TreeItem(node.label);
+        treeItem.tooltip = node.tooltip;
+        treeItem.iconPath = this._iconPaths[node.type];
+
+        if (this.getChildren(node).length !== 0) {
+            treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
         }
 
-        if (this._iconPaths[node.type]) {
-            treeItem.iconPath = this._iconPaths[node.type];
+        if (node.type === NodeType.Vertex) {
+            // Add a noop command to stop the item from expanding when clicking on the item label.
+            // See https://github.com/Microsoft/vscode/issues/34130#issuecomment-398783006.
+            // The actual handling of selection is in onDidSelectionChange to support multiselect.
+            treeItem.command = { title: '', command: 'gltf.noop' };
         }
 
         return treeItem;
@@ -534,23 +502,23 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
         return undefined;
     }
 
-    public getChildren(node?: Node): Node[] {
+    public getChildren(node?: Node, groupSize = 100): Node[] {
         if (!node) {
-            return this._roots || [];
+            return this._headerNode ? [this._headerNode, ...groupNodes(this._nodes, groupSize)] : [];
         }
 
         switch (node.type) {
+            case NodeType.Group: {
+                const groupNode = node as GroupNode;
+                return groupNode.nodes;
+            }
             case NodeType.AccessorMatrix: {
                 const accessorMatrixNode = node as AccessorMatrixNode;
                 return accessorMatrixNode.rows;
             }
-            case NodeType.DataGroup: {
-                const groupNode = node as DataGroupNode<Node>;
-                return groupNode.nodes;
-            }
             case NodeType.Vertices: {
                 const verticesNode = node as VerticesNode;
-                return verticesNode.nodes;
+                return groupNodes(verticesNode.nodes, groupSize);
             }
             case NodeType.Vertex: {
                 const vertexNode = node as VertexNode;
@@ -558,15 +526,15 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
             }
             case NodeType.Triangles: {
                 const trianglesNode = node as TrianglesNode;
-                return trianglesNode.nodes;
+                return groupNodes(trianglesNode.nodes, groupSize);
             }
             case NodeType.Lines: {
                 const linesNode = node as LinesNode;
-                return linesNode.nodes;
+                return groupNodes(linesNode.nodes, groupSize);
             }
             case NodeType.Points: {
                 const pointsNode = node as PointsNode;
-                return pointsNode.nodes;
+                return groupNodes(pointsNode.nodes, groupSize);
             }
         }
 
@@ -586,13 +554,14 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
 
         const accessor = getFromJsonPointer(gltf, jsonPointer) as GLTF2.Accessor;
 
-        const accessorNode: Node = {
-            type: NodeType.Header
+        this._headerNode = {
+            type: NodeType.Header,
+            label: this._jsonPointer
         };
 
-        this._roots = [accessorNode, ...getAccessorNodes(fileName, gltf, accessor)];
+        this._nodes = getAccessorNodes(fileName, gltf, accessor);
         this._onDidChangeTreeData.fire();
-        this._treeView.reveal(accessorNode, { select: false, focus: true });
+        this._treeView.reveal(this._headerNode, { select: false, focus: true });
     }
 
     public showMeshPrimitive(fileName: string, gltf: GLTF2.GLTF, jsonPointer: string): void {
@@ -603,21 +572,23 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
 
         const meshPrimitive = getFromJsonPointer(gltf, jsonPointer) as GLTF2.MeshPrimitive;
 
-        const meshPrimitiveNode: Node = {
-            type: NodeType.Header
+        this._headerNode = {
+            type: NodeType.Header,
+            label: this._jsonPointer
         };
 
         const verticesNode = getVerticesNode(this._fileName, gltf, meshPrimitive.attributes);
         const indicesNode = getIndicesNode(this._fileName, gltf, verticesNode.numVertices, meshPrimitive.mode, meshPrimitive.indices);
-        this._roots = [meshPrimitiveNode, verticesNode, indicesNode ];
+        this._nodes = [verticesNode, indicesNode];
         this._onDidChangeTreeData.fire();
-        this._treeView.reveal(meshPrimitiveNode, { select: false, focus: true });
+        this._treeView.reveal(this._headerNode, { select: false, focus: true });
     }
 
     private reset(): void {
         delete this._fileName;
         delete this._jsonPointer;
-        delete this._roots;
+        delete this._headerNode;
+        delete this._nodes;
         this._onDidChangeTreeData.fire();
     }
 


### PR DESCRIPTION
See #146 

This change adds to the inspect data view an item context menu item to copy an individual item and adds a title menu item to copy all the items.