### PR TITLE
Add support for editing multiple morph target animations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update BabylonJS logo
 * Fixed minor issue with font size in preview window.
 * Fixed issue with 3D preview not reloading after external changes to the glTF file. [#163](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/163)
+* Fixed issue with editing animations targeting multiple morph targets. [#165](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/165)
 
 ### 2.2.5 - 2019-05-05
 


### PR DESCRIPTION
While investigating https://github.com/KhronosGroup/glTF-Blender-IO/pull/521, I noticed that VSCode was not allowing me to import, edit, and re-export the morph target animation.  This is because the number of output values must be multiplied by the number of morph targets, [as shown here in the glTF Validator](https://github.com/KhronosGroup/glTF-Validator/blob/c70d030da87dea1620e80c19302c61f3c0b265c3/lib/src/base/animation.dart#L218-L222).