### PR TITLE
Watch all files referenced by glTF asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,13 +355,14 @@
         "watch:server": "cd server && npm run installServer && cd .. && tsc -w -p server/tsconfig.json"
     },
     "devDependencies": {
-        "ajv": "^5.5.2",
         "@types/mocha": "^2.2.48",
         "@types/node": "^8.10.12",
+        "ajv": "^5.5.2",
         "eslint": "^5.16.0",
         "eslint-config-cesium": "^7.0.0",
         "eslint-plugin-html": "^5.0.3",
         "mocha": "^4.1.0",
+        "tslint": "^5.17.0",
         "typescript": "^2.8.3",
         "vscode": "^1.1.21",
         "yargs": "^11.1.0"

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -80,7 +80,7 @@ function playAllOrNoAnimations(option) {
 
 /**
 * @function updatePreview
-* Stops any any ction from the active engine, and then updates
+* Stops any action from the active engine, and then updates
 * the DOM to use the newly selected engine.
 */
 function updatePreview() {
@@ -127,6 +127,10 @@ function initPreview()
 
     window.addEventListener('message', function(event) {
         switch (event.data.command) {
+            case 'refresh': {
+                updatePreview();
+                break;
+            }
             case 'enableDebugMode':
             case 'disableDebugMode': {
                 if (mainViewModel.selectedEngine().name === 'Babylon.js') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -702,15 +702,6 @@ export function activate(context: vscode.ExtensionContext) {
 
         activeTextEditor.selection = new vscode.Selection(newPointer.value.line, space.length * 5, newPointer.value.line, space.length * 5);
     }));
-
-    //
-    // Update all preview windows when the glTF file is saved.
-    //
-    vscode.workspace.onDidChangeTextDocument((event) => {
-        if (!event.document.isDirty) {
-            gltfWindow.preview.updatePanel(event.document);
-        }
-    });
 }
 
 // This method is called when your extension is deactivated.


### PR DESCRIPTION
See https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/163#issuecomment-498729502.

This works, but for textures, it seems to only update for Babylon. Not sure why, but Babylon somehow makes that the other two engines want to get the new texture also. Maybe it's some kind of caching going on, but I couldn't figure it out.