### PR TITLE
tslint fixes, dependency upgrades

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "extends": "./node_modules/eslint-config-cesium/browser.js",
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 2019,
+        "sourceType": "script"
     },
     "plugins": [
         "html"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "icon": "images/gltf.png",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.36.0"
     },
     "categories": [
         "Formatters",
@@ -355,17 +355,17 @@
         "watch:server": "cd server && npm run installServer && cd .. && tsc -w -p server/tsconfig.json"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.48",
-        "@types/node": "^8.10.12",
-        "ajv": "^5.5.2",
-        "eslint": "^5.16.0",
-        "eslint-config-cesium": "^7.0.0",
-        "eslint-plugin-html": "^5.0.3",
-        "mocha": "^4.1.0",
-        "tslint": "^5.17.0",
-        "typescript": "^2.8.3",
-        "vscode": "^1.1.21",
-        "yargs": "^11.1.0"
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^12.12.14",
+        "ajv": "^6.10.2",
+        "eslint": "^6.7.1",
+        "eslint-config-cesium": "^8.0.1",
+        "eslint-plugin-html": "^6.0.0",
+        "mocha": "^6.2.2",
+        "tslint": "^5.20.1",
+        "typescript": "^3.7.2",
+        "vscode": "^1.1.36",
+        "yargs": "^15.0.2"
     },
     "dependencies": {
         "babylonjs": "^4.0.3",
@@ -374,8 +374,8 @@
         "draco3dgltf": "1.3.4",
         "gltf-import-export": "1.0.15",
         "gltf-validator": "2.0.0-dev.2.7",
-        "json-source-map": "0.4.0",
-        "sprintf-js": "1.1.1",
-        "vscode-languageclient": "^3.5.1"
+        "json-source-map": "0.6.1",
+        "sprintf-js": "1.1.2",
+        "vscode-languageclient": "^5.2.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "icon": "images/gltf.png",
     "engines": {
-        "vscode": "^1.36.0"
+        "vscode": "^1.38.0"
     },
     "categories": [
         "Formatters",
@@ -347,7 +347,7 @@
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
-        "postinstall": "cd server && npm install && cd .. && node ./node_modules/vscode/bin/install",
+        "postinstall": "cd server && npm install && cd ..",
         "compile": "tsc -p ./tsconfig.json && cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
         "compile:client": "tsc -p ./tsconfig.json",
         "watch:client": "tsc -w -p ./tsconfig.json",
@@ -357,6 +357,7 @@
     "devDependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.12.14",
+        "@types/vscode": "^1.38.0",
         "ajv": "^6.10.2",
         "eslint": "^6.7.1",
         "eslint-config-cesium": "^8.0.1",
@@ -364,7 +365,6 @@
         "mocha": "^6.2.2",
         "tslint": "^5.20.1",
         "typescript": "^3.7.2",
-        "vscode": "^1.1.36",
         "yargs": "^15.0.2"
     },
     "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,9 +13,9 @@
     },
     "dependencies": {
         "gltf-validator": "2.0.0-dev.2.7",
-        "json-source-map": "0.4.0",
-        "vscode-languageserver": "^3.5.1",
-        "vscode-uri": "^1.0.6"
+        "json-source-map": "0.6.1",
+        "vscode-languageserver": "^5.2.1",
+        "vscode-uri": "^2.1.1"
     },
     "scripts": {
         "installServer": "installServerIntoExtension .. ./package.json ./tsconfig.json",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -22,13 +22,13 @@ let documents: TextDocuments = new TextDocuments();
 documents.listen(connection);
 
 interface JsonMap {
-    data: any,
+    data: any;
     pointers: any;
-};
+}
 
 interface ParseResult {
-    jsonMap: JsonMap,
-    parseable: boolean
+    jsonMap: JsonMap;
+    parseable: boolean;
 }
 
 let documentsToHandle: Map<TextDocument, ParseResult> = new Map<TextDocument, ParseResult>();
@@ -74,7 +74,7 @@ connection.onInitialize((): InitializeResult => {
             // Tell the client we provide definitions
             definitionProvider: true,
         }
-    }
+    };
 });
 
 // The settings interface describe the server relevant settings part
@@ -337,11 +337,11 @@ function getFromPath(glTF: any, path : string) {
 }
 
 interface PathData {
-    path: string,
-    start: Position,
-    end: Position,
-    jsonMap: JsonMap
-};
+    path: string;
+    start: Position;
+    end: Position;
+    jsonMap: JsonMap;
+}
 
 function getPath(textDocumentPosition: TextDocumentPositionParams): PathData {
     let hoverPos = textDocumentPosition.position;
@@ -390,13 +390,13 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
 
     function makeLocation(position?: any, uri?: string) {
         let range: Range;
-        if (position == null) {
+        if (!position) {
             range = Range.create(0, 0, 0, 0);
         } else {
             range = Range.create(document.positionAt(position.value.pos), document.positionAt(position.valueEnd.pos));
         }
 
-        if (uri == null) {
+        if (uri === undefined || uri === null) {
             uri = textDocumentPosition.textDocument.uri;
         }
 
@@ -418,7 +418,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
         let part = pathSplit[i];
         currentPath += '/' + part;
         result = result[part];
-        if (typeof result != 'object')
+        if (typeof result !== 'object')
         {
             if (part === 'scene') {
                 return makeLocation(pathData.jsonMap.pointers['/scenes/' + result]);
@@ -441,7 +441,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 if (primitive && primitive.extensions && primitive.extensions['KHR_draco_mesh_compression']) {
                     let indicesPath = primitivePath + '/extensions/KHR_draco_mesh_compression/attributes/indices';
                     let uri = makeDataUri(textDocumentPosition, indicesPath);
-                    return makeLocation(null, uri);
+                    return makeLocation(undefined, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
                 }
@@ -449,7 +449,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
             else if (part === 'POSITION' || part === 'NORMAL' || part === 'TANGENT'|| part === 'TEXCOORD_0' || part === 'TEXCOORD_1' || part === 'COLOR_0' || part === 'JOINTS_0' || part === 'WEIGHTS_0') {
                 if (inDraco) {
                     let uri = makeDataUri(textDocumentPosition, currentPath);
-                    return makeLocation(null, uri);
+                    return makeLocation(undefined, uri);
                 } else {
                     return makeLocation(pathData.jsonMap.pointers['/accessors/' + result]);
                 }
@@ -490,12 +490,12 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 inChannels = true;
                 currentAnimationPath = currentPath.substring(0, currentPath.length - '/channels'.length);
             }
-            else if (result.uri !== undefined) {
+            else if (result.uri !== undefined && result.uri !== null) {
                 if (!result.uri.startsWith('data:') && !currentPath.startsWith('/images/')) {
-                    return makeLocation(null, Url.resolve(textDocumentPosition.textDocument.uri, result.uri));
+                    return makeLocation(undefined, Url.resolve(textDocumentPosition.textDocument.uri, result.uri));
                 } else {
                     let uri = makeDataUri(textDocumentPosition, currentPath);
-                    return makeLocation(null, uri);
+                    return makeLocation(undefined, uri);
                 }
             } else if (part === 'accessors') {
                 inAccessors = true;
@@ -503,7 +503,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
                 inDraco = true;
             } else if (inAccessors && !path.includes('bufferView')) {
                 let uri = makeDataUri(textDocumentPosition, currentPath);
-                return makeLocation(null, uri);
+                return makeLocation(undefined, uri);
             }
         }
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,7 +3,7 @@ import {
     Diagnostic, DiagnosticSeverity, InitializeResult, Position, Range, TextDocumentPositionParams, Hover, MarkedString,
     Location
 } from 'vscode-languageserver';
-import Uri from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import * as Url from 'url';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -179,7 +179,7 @@ function clearTextDocument(textDocument: TextDocument): void {
 function parseTextDocument(parseResult: ParseResult, textDocument: TextDocument): void {
     console.log('validate ' + textDocument.uri);
 
-    const fileName = Uri.parse(textDocument.uri).fsPath;
+    const fileName = URI.parse(textDocument.uri).fsPath;
     const baseName = path.basename(fileName);
 
     const gltfText = textDocument.getText();
@@ -404,7 +404,7 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
     }
 
     function makeDataUri(doc: TextDocumentPositionParams, path: string): string {
-        return 'gltf-dataUri:' + path + '#' + encodeURIComponent(Uri.parse(doc.textDocument.uri).fsPath);
+        return 'gltf-dataUri:' + path + '#' + encodeURIComponent(URI.parse(doc.textDocument.uri).fsPath);
     }
 
     const firstValidIndex = 1; // Because the path has a leading slash.

--- a/src/dataUriTextDocumentContentProvider.ts
+++ b/src/dataUriTextDocumentContentProvider.ts
@@ -53,7 +53,7 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
 
     public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
         const fileName = decodeURIComponent(uri.fragment);
-        const query = querystring.parse<QueryDataUri>(uri.query);
+        const query = querystring.parse(uri.query);
         query.viewColumn = query.viewColumn || vscode.ViewColumn.Active.toString();
         let glTFContent: string;
         const document = vscode.workspace.textDocuments.find(e => e.uri.scheme === 'file' && e.fileName === fileName);
@@ -89,7 +89,7 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
                             vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                         }
                         const previewUri: vscode.Uri = vscode.Uri.parse(this.UriPrefix + uri.path + '?previewHtml=true' + '#' + encodeURIComponent(fileName));
-                        await vscode.commands.executeCommand('vscode.previewHtml', previewUri, parseInt(query.viewColumn));
+                        await vscode.commands.executeCommand('vscode.previewHtml', previewUri, parseInt(query.viewColumn.toString()));
                         return '';
                     } else {
                         return `<html><head><link rel="stylesheet" href="file:///${this._context.asAbsolutePath('pages/imagePreview.css')}"></link></head>` +

--- a/src/dataUriTextDocumentContentProvider.ts
+++ b/src/dataUriTextDocumentContentProvider.ts
@@ -10,8 +10,8 @@ import { GLTF2 } from './GLTF2';
 const decoderModule = draco3dgltf.createDecoderModule({});
 
 interface QueryDataUri {
-    viewColumn?: string,
-    previewHtml?: string,
+    viewColumn?: string;
+    previewHtml?: string;
 }
 
 export class DataUriTextDocumentContentProvider implements vscode.TextDocumentContentProvider {
@@ -82,10 +82,10 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
                 if (this.isImage(jsonPointer)) {
                     if (!query.previewHtml || query.previewHtml !== 'true') {
                         // Peek Definition requests have a document that matches the current document
-                        // Go to Definition has a null activeTextEditor
+                        // Go to Definition has an undefined activeTextEditor
                         // Inspect Data Uri has a document that matches current but we provide a non-default viewColumn
                         // In the last two cases we want to close the current (to be empty editor), for Peek we leave it open.
-                        if (vscode.window.activeTextEditor == null || vscode.window.activeTextEditor.document != document || query.viewColumn != vscode.ViewColumn.Active.toString()) {
+                        if (vscode.window.activeTextEditor === undefined || vscode.window.activeTextEditor.document !== document || query.viewColumn !== vscode.ViewColumn.Active.toString()) {
                             vscode.commands.executeCommand('workbench.action.closeActiveEditor');
                         }
                         const previewUri: vscode.Uri = vscode.Uri.parse(this.UriPrefix + uri.path + '?previewHtml=true' + '#' + encodeURIComponent(fileName));
@@ -120,7 +120,7 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
         const numComponents = AccessorTypeToNumComponents[accessor.type];
         for (let index = 0; index < accessor.count; index++) {
             const values = getAccessorElement(data, index, numComponents, accessor.componentType, accessor.normalized);
-            const format = (accessor.componentType === GLTF2.AccessorComponentType.FLOAT || accessor.normalized) ? '%11.5f' : '%5d'
+            const format = (accessor.componentType === GLTF2.AccessorComponentType.FLOAT || accessor.normalized) ? '%11.5f' : '%5d';
             if (accessor.type.startsWith('MAT')) {
                 const size = Math.sqrt(numComponents);
                 for (let rowIndex = 0; rowIndex < size; rowIndex++) {
@@ -139,20 +139,20 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
 
     private formatDraco(glTF: GLTF2.GLTF, jsonPointer: string, fileName: string): string {
         const attrIndex = jsonPointer.lastIndexOf('/');
-        if (attrIndex == -1) {
+        if (attrIndex === -1) {
             return 'Invalid path:\n' + jsonPointer;
         }
         let attrName = jsonPointer.substr(attrIndex + 1);
         const dracoIndex = jsonPointer.lastIndexOf('/', attrIndex - 1);
-        if (dracoIndex == -1) {
+        if (dracoIndex === -1) {
             return 'Invalid path:\n' + jsonPointer;
         }
         const extIndex = jsonPointer.lastIndexOf('/', dracoIndex - 1);
-        if (extIndex == -1) {
+        if (extIndex === -1) {
             return 'Invalid path:\n' + jsonPointer;
         }
         const primitiveIndex = jsonPointer.lastIndexOf('/', extIndex - 1);
-        if (primitiveIndex == -1) {
+        if (primitiveIndex === -1) {
             return 'Invalid path:\n' + jsonPointer;
         }
         const primitivePointer = jsonPointer.substring(0, primitiveIndex);
@@ -217,7 +217,7 @@ export class DataUriTextDocumentContentProvider implements vscode.TextDocumentCo
                 const numComponents = attribute.num_components();
                 for (let i = 0; i < (numPoints * numComponents); i++) {
                     const value = dracoMeshData.GetValue(i);
-                    if (i % numComponents == 0 && i !== 0) {
+                    if (i % numComponents === 0 && i !== 0) {
                         result += '\n';
                     }
                     if (accessor.componentType === GLTF2.AccessorComponentType.FLOAT) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ export function activateServer(context: vscode.ExtensionContext) {
     let serverOptions: ServerOptions = {
         run: { module: serverModule, transport: TransportKind.ipc },
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
-    }
+    };
 
     // Options to control the language client
     let clientOptions: LanguageClientOptions = {
@@ -95,7 +95,7 @@ export function activateServer(context: vscode.ExtensionContext) {
             // Notify the server about file changes to '.clientrc files contain in the workspace
             fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
         }
-    }
+    };
 
     // Create the language client and start the client.
     let disposable = new LanguageClient('gltfLanguageServer', 'glTF Language Server', serverOptions, clientOptions).start();
@@ -281,7 +281,7 @@ export function activate(context: vscode.ExtensionContext) {
             let extension;
             let mimeType = '';
             if (mimeTypePos > 0) {
-                mimeType = dataUri.substring(5, mimeTypePos)
+                mimeType = dataUri.substring(5, mimeTypePos);
                 extension = guessFileExtension(mimeType);
                 guessName += extension;
             }
@@ -398,7 +398,7 @@ export function activate(context: vscode.ExtensionContext) {
     //
     context.subscriptions.push(vscode.commands.registerCommand('gltf.importGlbFile', async (fileUri) => {
 
-        if (typeof fileUri == 'undefined' || !(fileUri instanceof vscode.Uri) || !fileUri.fsPath.endsWith('.glb')) {
+        if (typeof fileUri === 'undefined' || !(fileUri instanceof vscode.Uri) || !fileUri.fsPath.endsWith('.glb')) {
             if ((vscode.window.activeTextEditor !== undefined) &&
                 (vscode.window.activeTextEditor.document.uri.fsPath.endsWith('.glb'))) {
                 fileUri = vscode.window.activeTextEditor.document.uri;
@@ -422,7 +422,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         try {
-            if (typeof fileUri.fsPath == 'undefined') {
+            if (typeof fileUri.fsPath === 'undefined') {
                 return;
             }
             if (!fs.existsSync(fileUri.fsPath)) {
@@ -441,15 +441,15 @@ export function activate(context: vscode.ExtensionContext) {
                     };
                     let uri = await vscode.window.showSaveDialog(options);
                     if (!uri) {
-                        return null;
+                        return undefined;
                     }
                     targetFilename = uri.fsPath;
                 }
                 return targetFilename;
-            }
+            };
             let targetFilename = await ConvertGLBtoGltfLoadFirst(fileUri.fsPath, getTargetFilename);
 
-            if (targetFilename != null) {
+            if (targetFilename) {
                 vscode.commands.executeCommand('vscode.open', vscode.Uri.file(targetFilename));
             }
         } catch (ex) {
@@ -461,7 +461,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Run the validator on an external file.
     //
     context.subscriptions.push(vscode.commands.registerCommand('gltf.validateFile', async (fileUri) => {
-        if (typeof fileUri == 'undefined' || !(fileUri instanceof vscode.Uri) ||
+        if (typeof fileUri === 'undefined' || !(fileUri instanceof vscode.Uri) ||
             !(fileUri.fsPath.endsWith('.glb') || fileUri.fsPath.endsWith('.gltf'))) {
             const options: vscode.OpenDialogOptions = {
                 canSelectMany: false,
@@ -496,8 +496,8 @@ export function activate(context: vscode.ExtensionContext) {
         let path = '';
         const firstValidIndex = 1; // Because the path has a leading slash.
         for (let i = firstValidIndex; i < numPointerSegments; ++i) {
-            inAnimation = inAnimation || (jsonPointerSplit[i] == 'animations');
-            inSampler = inAnimation && (inSampler || (jsonPointerSplit[i] == 'samplers'));
+            inAnimation = inAnimation || (jsonPointerSplit[i] === 'animations');
+            inSampler = inAnimation && (inSampler || (jsonPointerSplit[i] === 'samplers'));
             result = result[jsonPointerSplit[i]];
             path += '/' + jsonPointerSplit[i];
         }
@@ -538,7 +538,7 @@ export function activate(context: vscode.ExtensionContext) {
             const accessorId = animationPointer.json[key];
             const accessor = glTF.accessors[accessorId];
             let data: ArrayLike<number> = [];
-            if (accessor != undefined) {
+            if (accessor !== undefined) {
                 data = getAccessorData(activeTextEditor.document.fileName, glTF, accessor);
             }
             animationPointer.json.extras[`vscode_gltf_${key}`] = Array.from(data);
@@ -548,7 +548,7 @@ export function activate(context: vscode.ExtensionContext) {
         const pointer = map.pointers[animationPointer.path];
 
         const tabSize = activeTextEditor.options.tabSize as number;
-        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t'
+        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';
         let newJson = JSON.stringify(animationPointer.json, null, space);
         const newJsonLines = newJson.split(/\n/);
         const fullTab = new Array(5).join(space);
@@ -596,14 +596,14 @@ export function activate(context: vscode.ExtensionContext) {
 
         const samplerType = animationPointer.json.extras.vscode_gltf_type;
         const components = AccessorTypeToNumComponents[samplerType];
-        let entriesPerComponent = animationPointer.json.interpolation == 'CUBICSPLINE' ? 3 : 1;
+        let entriesPerComponent = animationPointer.json.interpolation === 'CUBICSPLINE' ? 3 : 1;
 
         // Check if this is a multi-target morph animation.
         const animationIndex = +animationPointer.path.split('/')[2];
         const outerAnimation = glTF.animations[animationIndex];
         if (outerAnimation.channels && outerAnimation.channels[0]) {
             const firstChannel = outerAnimation.channels[0];
-            if (firstChannel.target && firstChannel.target.path == 'weights') {
+            if (firstChannel.target && firstChannel.target.path === 'weights') {
                 const animatedNode = glTF.nodes[firstChannel.target.node];
                 const animatedMesh = glTF.meshes[animatedNode.mesh];
                 const numTargets = animatedMesh.primitives[0].targets.length;
@@ -615,20 +615,20 @@ export function activate(context: vscode.ExtensionContext) {
             input: animationPointer.json.extras.vscode_gltf_input,
             output: animationPointer.json.extras.vscode_gltf_output
         };
-        if ((newData.input.length * components * entriesPerComponent) != newData.output.length) {
+        if ((newData.input.length * components * entriesPerComponent) !== newData.output.length) {
             vscode.window.showErrorMessage(`Number of input values (${newData.input.length}) does not equal output values (${newData.output.length / components / entriesPerComponent}).`);
             return;
         }
         delete animationPointer.json.extras.vscode_gltf_type;
         delete animationPointer.json.extras.vscode_gltf_input;
         delete animationPointer.json.extras.vscode_gltf_output;
-        if (Object.keys(animationPointer.json.extras).length == 0) {
+        if (Object.keys(animationPointer.json.extras).length === 0) {
             delete animationPointer.json.extras;
         }
 
         const inputAccessor = glTF.accessors[animationPointer.json.input];
         let bufferIndex = 0;
-        if (inputAccessor != undefined) {
+        if (inputAccessor !== undefined) {
             const bufferView = glTF.bufferViews[inputAccessor.bufferView];
             bufferIndex = bufferView.buffer;
         }
@@ -636,7 +636,7 @@ export function activate(context: vscode.ExtensionContext) {
         const bufferData = getBuffer(glTF, bufferIndex, activeTextEditor.document.fileName);
         const alignedLength = (value: number) => {
             const alignValue = 4;
-            if (value == 0) {
+            if (value === 0) {
                 return value;
             }
 
@@ -646,17 +646,17 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             return value + (alignValue - multiple);
-        }
+        };
         let bufferOffset = alignedLength(bufferData.length);
 
         const outputBuffers = [bufferData];
-        if (bufferOffset != bufferData.length) {
+        if (bufferOffset !== bufferData.length) {
             outputBuffers.push(new Buffer(bufferOffset - bufferData.length));
         }
 
         for (const accessorType of ['input', 'output']) {
             const values = newData[accessorType];
-            const accessorComponents = accessorType == 'input' ? 1 : components;
+            const accessorComponents = accessorType === 'input' ? 1 : components;
             const max = new Array(accessorComponents).fill(Number.NEGATIVE_INFINITY);
             for (let i = 0; i < values.length; i++) {
                 const j = i % accessorComponents;
@@ -672,13 +672,13 @@ export function activate(context: vscode.ExtensionContext) {
                 "bufferView": glTF.bufferViews.length,
                 "componentType": 5126,
                 "count": values.length / accessorComponents,
-                "type": accessorType == 'input' ? 'SCALAR' : samplerType,
+                "type": accessorType === 'input' ? 'SCALAR' : samplerType,
                 "max": max,
                 "min": min
             };
 
             const accessorId = animationPointer.json[accessorType];
-            if (glTF.accessors[accessorId] == undefined) {
+            if (glTF.accessors[accessorId] === undefined) {
                 animationPointer.json[accessorType] = glTF.accessors.length;
                 glTF.accessors.push(accessor);
             } else {
@@ -691,7 +691,7 @@ export function activate(context: vscode.ExtensionContext) {
                 "byteLength": float32Values.byteLength,
             };
             glTF.bufferViews.push(newBufferView);
-            if (alignedLength(float32Values.byteLength) != float32Values.byteLength) {
+            if (alignedLength(float32Values.byteLength) !== float32Values.byteLength) {
                 throw new Error('Float32Array not 4 byte length');
             }
             bufferOffset += float32Values.byteLength;
@@ -703,7 +703,7 @@ export function activate(context: vscode.ExtensionContext) {
         bufferJson.uri = 'data:application/octet-stream;base64,' + finalBuffer.toString('base64');
         bufferJson.byteLength = finalBuffer.length;
         const tabSize = activeTextEditor.options.tabSize as number;
-        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t'
+        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';
         const newJson = JSON.stringify(glTF, null, space);
 
         const newRange = new vscode.Range(0, 0, activeTextEditor.document.lineCount + 1, 0);

--- a/src/gltfInspectData.ts
+++ b/src/gltfInspectData.ts
@@ -263,7 +263,7 @@ function getVerticesNode(fileName: string, gltf: GLTF2.GLTF, attributes: { [name
             index: index,
             attributeNodes: attributeNodes
         };
-    };
+    }
 
     return {
         type: NodeType.Vertices,
@@ -377,18 +377,18 @@ function getPointNodes(numVertices: number, data: ArrayLike<number> | undefined)
             label: `${index}`,
             index: index,
             vertex: get(index)
-        }
+        };
     }
 
     return nodes;
 }
 
 function getIndicesNode(fileName: string, gltf: GLTF2.GLTF, numVertices: number, mode: GLTF2.MeshPrimitiveMode | undefined, indices: number | undefined): TrianglesNode | LinesNode | PointsNode {
-    if (mode == undefined) {
+    if (mode === undefined) {
         mode = GLTF2.MeshPrimitiveMode.TRIANGLES;
     }
 
-    const accessor = indices != undefined && gltf.accessors[indices];
+    const accessor = indices !== undefined && gltf.accessors[indices];
     const data = accessor && getAccessorData(fileName, gltf, accessor);
     switch (mode) {
         case GLTF2.MeshPrimitiveMode.TRIANGLES:
@@ -426,7 +426,7 @@ function getIconPath(context: vscode.ExtensionContext, name: string): { light: s
     return {
         light: context.asAbsolutePath(path.join('resources', 'light', `${name}.svg`)),
         dark: context.asAbsolutePath(path.join('resources', 'dark', `${name}.svg`))
-    }
+    };
 }
 
 export class GltfInspectData implements vscode.TreeDataProvider<Node> {
@@ -470,7 +470,7 @@ export class GltfInspectData implements vscode.TreeDataProvider<Node> {
                     text += `${indent}${node.label}${os.EOL}`;
                     traverseNodes(this.getChildren(node, Number.MAX_VALUE), `  ${indent}`);
                 }
-            }
+            };
 
             traverseNodes(this._nodes, '');
 

--- a/src/gltfOutline.ts
+++ b/src/gltfOutline.ts
@@ -22,7 +22,7 @@ interface GltfNode {
 interface MeshInfo {
     size: number;
     vertices: number;
-};
+}
 
 export class GltfOutline implements vscode.TreeDataProvider<GltfNode> {
     private tree: GltfNode;
@@ -429,7 +429,7 @@ export class GltfOutline implements vscode.TreeDataProvider<GltfNode> {
         };
         if (mesh.primitives) {
             for (let primitiveIndex = 0; primitiveIndex < mesh.primitives.length; primitiveIndex++) {
-                let primitiveInfo = this.createMeshPrimitive(mesh, meshIndex, primitiveIndex.toString(), meshObj, assetReport)
+                let primitiveInfo = this.createMeshPrimitive(mesh, meshIndex, primitiveIndex.toString(), meshObj, assetReport);
                 if (assetReport) {
                     meshInfo.size += primitiveInfo.size;
                     meshInfo.vertices += primitiveInfo.vertices;
@@ -622,7 +622,7 @@ export class GltfOutline implements vscode.TreeDataProvider<GltfNode> {
         if (set.size === 0) {
             return '';
         }
-        return ` (Skin${set.size == 1 ? '' : 's'} ${Array.from(set.values()).join(', ')})`;
+        return ` (Skin${set.size === 1 ? '' : 's'} ${Array.from(set.values()).join(', ')})`;
     }
 
     private getIcon(nodeType: GltfNodeType): any {
@@ -633,6 +633,6 @@ export class GltfOutline implements vscode.TreeDataProvider<GltfNode> {
         return {
             light: this.context.asAbsolutePath(path.join('resources', 'light', nodeType + '.svg')),
             dark: this.context.asAbsolutePath(path.join('resources', 'dark', nodeType + '.svg'))
-        }
+        };
     }
 }

--- a/src/gltfWindow.ts
+++ b/src/gltfWindow.ts
@@ -81,5 +81,5 @@ export class GltfWindow {
             this._activeTextEditor = activeTextEditor;
             this._onDidChangeActiveTextEditor.fire(activeTextEditor);
         }
-    };
+    }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -51,7 +51,7 @@ function buildArrayBuffer<T extends ArrayLike<number>>(typedArray: any, data: Ar
 
     const targetLength = count * numComponents;
 
-    if (byteStride == null || byteStride === numComponents * typedArray.BYTES_PER_ELEMENT) {
+    if (byteStride === undefined || byteStride === numComponents * typedArray.BYTES_PER_ELEMENT) {
         return new typedArray(data.buffer, byteOffset, targetLength);
     }
 
@@ -74,7 +74,7 @@ function buildArrayBuffer<T extends ArrayLike<number>>(typedArray: any, data: Ar
 }
 
 export function getAccessorData(fileName: string, gltf: GLTF2.GLTF, accessor: GLTF2.Accessor): ArrayLike<number> | undefined {
-    if (accessor.bufferView == undefined) {
+    if (accessor.bufferView === undefined) {
         return undefined;
     }
 

--- a/src/validationProvider.ts
+++ b/src/validationProvider.ts
@@ -26,7 +26,7 @@ function messageLabel(howMany: Number, name: string) {
 }
 
 export async function validate(sourceFilename: string) {
-    if (typeof sourceFilename == 'undefined') {
+    if (typeof sourceFilename === 'undefined') {
         return;
     }
     if (!fs.existsSync(sourceFilename)) {
@@ -44,7 +44,7 @@ export async function validate(sourceFilename: string) {
         maxIssues: currentSettings.maxIssues,
         ignoredIssues: currentSettings.ignoredIssues,
         severityOverrides: currentSettings.severityOverrides,
-        externalResourceFunction: (uri) =>
+        externalResourceFunction: (uri : string) =>
             new Promise((resolve, reject) => {
                 uri = path.resolve(folderName, decodeURIComponent(uri));
                 fs.readFile(uri, (err, data) => {


### PR DESCRIPTION
Fix a bunch of nits reported by tslint.

This has the power to break a number of things, because many `== null` checks were quite loose and matching values such as `undefined`, `false`, and even `0` and empty string.

Making these more specific caused some disagreement whether `undefined` or `null` means there's no value, and in some places, both are accepted.

I did some testing and I hope I caught all the problem spots, but more testing is always appreciated.