### PR TITLE
Adjust UI for better fit, add "small mode" for tight spots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added JSON schema for KHR_materials_transmission, KHR_xmp, and EXT_mesh_gpu_instancing [#193](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/193)
 * Added JSON schema for KHR_materials_variants [#189](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/189)
+* Fixed an issue with buttons sticking off the edge in the default Windows Japanese font. [#190](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/190)
 
 ### 2.3.0 - 2020-08-24
 

--- a/pages/previewModel.css
+++ b/pages/previewModel.css
@@ -20,7 +20,7 @@ html, body {
     position: absolute;
     top: 0;
     right: 20px;
-    width: 310px;
+    width: 330px;
     color: #ddd;
     /* Hide controls */
     opacity: 0.3;
@@ -252,7 +252,7 @@ label:hover .angleBox::before {
 .rowUI input[type=range i] {
     margin-top: 12px;
     margin-bottom: 15px;
-    width: 156px;
+    width: 220px;
     position: relative;
     top: -2px;
 }
@@ -266,4 +266,50 @@ label:hover .angleBox::before {
 
 .rowUI input[type=range i]::-webkit-slider-thumb {
     margin-top: -11px;
+}
+
+/* Small mode */
+@media (max-width: 400px) {
+    html, body {
+        font-size: 10px;
+    }
+
+    #mainUI {
+        width: 255px;
+    }
+
+    .topUI {
+        border-bottom-width: 0.9rem;
+        border-right-width: 0.9rem;
+    }
+
+    .topUI span {
+        bottom: -1.3rem;
+    }
+
+    .bottomUI span {
+        top: -1.2rem;
+    }
+
+    .topUI span,
+    .bottomUI span,
+    .smallHeading {
+        font-size: 0.9rem;
+    }
+
+    .angleBox {
+        height: 7px;
+    }
+
+    .active .angleBox > span::before {
+        height: 0;
+    }
+
+    .active .angleBox > span::after {
+        top: 4px;
+    }
+
+    .rowUI input[type=range i] {
+        width: 156px;
+    }
 }


### PR DESCRIPTION
This makes the main UI even wider, to accommodate wider fonts such as [Meiryo](https://answers.microsoft.com/en-us/windows/forum/all/how-to-get-meiryo-ui-font-in-windows-10/25930001-0585-4892-b58e-cb668e58da5f).

Also it adds a "small mode", where if the width of the preview window is less than 400 pixels wide, the UI will shrink a bit to try to stay within bounds.

Fixes #190.
