### PR TITLE
Hover color sample images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 2.3.5 - UNRELEASED
+
+* Hovering a color (such as `baseColorFactor`, etc) now converts the color from linear to sRGB colorspace for proper display.
+* Hovering a color no longer requires network access for the sample. [#207](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/207)
+* Various glTF extensions that supply color factors can now also be hovered.  Also [#207](https://github.com/AnalyticalGraphicsInc/gltf-vscode/issues/207)
+
 ### 2.3.4 - 2021-01-18
 
 * Fixed packaging error in previous version that broke the preview window.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -505,11 +505,21 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
     return null;
 });
 
+function linearToSRGB(red: number, green: number, blue: number): string | null {
+    const l2sRGB = (c: number) => (c <= 0.0031308) ? (c * 12.92) : (1.055 * Math.pow(c, 1 / 2.4) - 0.055);
+
+    red = Math.round(l2sRGB(red) * 255);
+    green = Math.round(l2sRGB(green) * 255);
+    blue = Math.round(l2sRGB(blue) * 255);
+    return ((red < 16) ? '0' : '') + red.toString(16) + ((green < 16) ? '0' : '') + green.toString(16) + ((blue < 16) ? '0' : '') + blue.toString(16);
+}
+
 const colorFactorNames = [
+    'ColorFactor',  // Note: This includes anything that ends with ...ColorFactor
     'diffuseFactor',
     'specularFactor',
-    'baseColorFactor',
-    'emissiveFactor'
+    'emissiveFactor',
+    'attenuationColor'
 ];
 
 connection.onHover((textDocumentPosition: TextDocumentPositionParams): Hover => {
@@ -543,24 +553,23 @@ connection.onHover((textDocumentPosition: TextDocumentPositionParams): Hover => 
             path = path.substring(0, path.length-2);
         }
         let colorData = getFromPath(pathData.jsonMap.data, path);
-        let red = Math.round(colorData[0] * 255);
-        let blue = Math.round(colorData[1] * 255);
-        let green = Math.round(colorData[2] * 255);
-        let hexColor = ((red < 16) ? '0' : '') + red.toString(16) + ((blue < 16) ? '0' : '') +  blue.toString(16) + ((green < 16) ? '0' : '') +  green.toString(16);
-        let svg =
-            `<?xml version="1.0" encoding="UTF-8" standalone="no"?>` +
-            `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="45" viewBox="0 0 180 45">` +
-            `<rect style="fill:#${hexColor}" width="100%" height="100%" x="0" y="0" />` +
-            `</svg>`;
-        let svgDataUri = 'data:image/svg+xml;base64,' + Buffer.from(svg).toString('base64');  // This is inline btoa(svg).
-        let contents: MarkupContent = {
-            kind: MarkupKind.Markdown,
-            value: `![#${hexColor}](${svgDataUri})`
-        };
-        return {
-            contents: contents,
-            range: Range.create(pathData.start, pathData.end)
-        };
+        if (Array.isArray(colorData) && colorData.length >= 3) {
+            let hexColor = linearToSRGB(colorData[0], colorData[1], colorData[2]);
+            let svg =
+                `<?xml version="1.0" encoding="UTF-8" standalone="no"?>` +
+                `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="45" viewBox="0 0 300 45">` +
+                `<rect style="fill:#${hexColor}" width="100%" height="100%" x="0" y="0" />` +
+                `</svg>`;
+            let svgDataUri = 'data:image/svg+xml;base64,' + Buffer.from(svg).toString('base64');  // This is inline btoa(svg).
+            let contents: MarkupContent = {
+                kind: MarkupKind.Markdown,
+                value: `![#${hexColor}](${svgDataUri})  \nConverted linear to sRGB color: \`#${hexColor}\``
+            };
+            return {
+                contents: contents,
+                range: Range.create(pathData.start, pathData.end)
+            };
+        }
     }
 
     return null;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -505,6 +505,13 @@ connection.onDefinition((textDocumentPosition: TextDocumentPositionParams): Loca
     return null;
 });
 
+const colorFactorNames = [
+    'diffuseFactor',
+    'specularFactor',
+    'baseColorFactor',
+    'emissiveFactor'
+];
+
 connection.onHover((textDocumentPosition: TextDocumentPositionParams): Hover => {
     let pathData = getPath(textDocumentPosition);
     if (!pathData) {
@@ -531,8 +538,7 @@ connection.onHover((textDocumentPosition: TextDocumentPositionParams): Hover => 
         }
     }
 
-    if (path.includes('diffuseFactor') || path.includes('specularFactor') || path.includes('baseColorFactor') || path.includes('emissiveFactor'))
-    {
+    if (colorFactorNames.some(n => path.includes(n))) {
         if (!Number.isNaN(parseInt(path.charAt(path.length-1)))) {
             path = path.substring(0, path.length-2);
         }
@@ -541,9 +547,15 @@ connection.onHover((textDocumentPosition: TextDocumentPositionParams): Hover => 
         let blue = Math.round(colorData[1] * 255);
         let green = Math.round(colorData[2] * 255);
         let hexColor = ((red < 16) ? '0' : '') + red.toString(16) + ((blue < 16) ? '0' : '') +  blue.toString(16) + ((green < 16) ? '0' : '') +  green.toString(16);
+        let svg =
+            `<?xml version="1.0" encoding="UTF-8" standalone="no"?>` +
+            `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="45" viewBox="0 0 180 45">` +
+            `<rect style="fill:#${hexColor}" width="100%" height="100%" x="0" y="0" />` +
+            `</svg>`;
+        let svgDataUri = 'data:image/svg+xml;base64,' + Buffer.from(svg).toString('base64');  // This is inline btoa(svg).
         let contents: MarkupContent = {
             kind: MarkupKind.Markdown,
-            value: `![${hexColor}](https://placehold.it/50/${hexColor}/000000?text=+)`
+            value: `![#${hexColor}](${svgDataUri})`
         };
         return {
             contents: contents,


### PR DESCRIPTION
- Hovering a color (such as `baseColorFactor`, etc) now converts the color from linear to sRGB colorspace for proper display.
- Hovering a color no longer requires network access for the sample.
- Various glTF extensions that supply color factors can now also be hovered.

Fixes #207.

