### PR TITLE
Get rid of default non-IBL light sources

### DIFF
--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -128,7 +128,7 @@
 
             BABYLON.GLTFFileLoader.IncrementalLoading = false;
             BABYLON.SceneLoader.AppendAsync(rootPath, 'data:' + gltfContent, scene, undefined, '.gltf').then(function () {
-                scene.createDefaultCameraOrLight(true);
+                scene.createDefaultCamera(true);
                 scene.activeCamera.attachControl(canvas);
                 scene.activeCamera.wheelDeltaPercentage = 0.05;
 

--- a/pages/threeView.js
+++ b/pages/threeView.js
@@ -45,9 +45,6 @@ export class ThreeView {
 
         scene.add(camera);
 
-        var hemispheric = new THREE.HemisphereLight(0xffffff, 0x222222, 0.5);
-        scene.add(hemispheric);
-
         // RENDERER
         var renderer = this._renderer = new THREE.WebGLRenderer({ antialias: true, logarithmicDepthBuffer: true });
         renderer.setClearColor(0x222222);


### PR DESCRIPTION
This turns off some default light sources in the Babylon and ThreeJS viewers, leaving the IBL as the main and only light source for the model.

Fixes #210.
