### PR TITLE
add gltf.openGlbFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "onCommand:gltf.previewModel",
         "onCommand:gltf.validateFile",
         "onCommand:gltf.exportGlbFile",
-        "onCommand:gltf.importGlbFile"
+        "onCommand:gltf.importGlbFile",
+        "onCommand:gltf.openGlbFile"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -178,6 +179,10 @@
                 "title": "glTF: Import from GLB"
             },
             {
+                "command": "gltf.openGlbFile",
+                "title": "glTF: Open GLB"
+            },
+            {
                 "command": "gltf.importAnimation",
                 "title": "glTF: Import animation"
             },
@@ -230,6 +235,10 @@
             "explorer/context": [
                 {
                     "command": "gltf.importGlbFile",
+                    "group": "glTF"
+                },
+                {
+                    "command": "gltf.openGlbFile",
                     "group": "glTF"
                 },
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import { getFromJsonPointer, guessMimeType, btoa, guessFileExtension, getAccessorData, AccessorTypeToNumComponents, parseJsonMap, truncateJsonPointer } from './utilities';
 import { GLTF2 } from './GLTF2';
 import { GltfWindow } from './gltfWindow';
+import { GlbProvider } from './glbProvider';
 
 function checkValidEditor(): boolean {
     if (vscode.window.activeTextEditor === undefined) {
@@ -455,6 +456,23 @@ export function activate(context: vscode.ExtensionContext): void {
         } catch (ex) {
             vscode.window.showErrorMessage(ex.toString());
         }
+    }));
+
+    //
+    // Virtual TextDocumentContentProvider for glb json chunk.
+    //
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('glb', new GlbProvider()));
+
+    //
+    // Open GLB with 'glb:' schema, and send GlbProvider.
+    //
+    context.subscriptions.push(vscode.commands.registerCommand('gltf.openGlbFile', async (fileUri) => {
+
+        const uri = vscode.Uri.parse('glb:' + fileUri.fsPath);
+        const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
+        vscode.languages.setTextDocumentLanguage(doc, "json");
+        await vscode.window.showTextDocument(doc, { preview: true });
+
     }));
 
     //

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import { getFromJsonPointer, guessMimeType, btoa, guessFileExtension, getAccessorData, AccessorTypeToNumComponents, parseJsonMap, truncateJsonPointer } from './utilities';
 import { GLTF2 } from './GLTF2';
 import { GltfWindow } from './gltfWindow';
-import { GlbProvider } from './glbProvider';
+import { GlbTextDocumentContentProvider } from './glbTextDocumentContentProvider';
 
 function checkValidEditor(): boolean {
     if (vscode.window.activeTextEditor === undefined) {
@@ -461,7 +461,7 @@ export function activate(context: vscode.ExtensionContext): void {
     //
     // Virtual TextDocumentContentProvider for glb json chunk.
     //
-    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('glb', new GlbProvider()));
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('glb', new GlbTextDocumentContentProvider()));
 
     //
     // Open GLB with 'glb:' schema, and send GlbProvider.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -468,7 +468,8 @@ export function activate(context: vscode.ExtensionContext): void {
     //
     context.subscriptions.push(vscode.commands.registerCommand('gltf.openGlbFile', async (fileUri) => {
 
-        const uri = vscode.Uri.parse('glb:' + fileUri.fsPath);
+        const virtualTextPath = `glb:${fileUri.fsPath}.json`;
+        const uri = vscode.Uri.parse(virtualTextPath);
         const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
         vscode.languages.setTextDocumentLanguage(doc, "json");
         await vscode.window.showTextDocument(doc, { preview: false });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -471,7 +471,7 @@ export function activate(context: vscode.ExtensionContext): void {
         const uri = vscode.Uri.parse('glb:' + fileUri.fsPath);
         const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
         vscode.languages.setTextDocumentLanguage(doc, "json");
-        await vscode.window.showTextDocument(doc, { preview: true });
+        await vscode.window.showTextDocument(doc, { preview: false });
 
     }));
 

--- a/src/glbProvider.ts
+++ b/src/glbProvider.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+//
+// Virtual TextDocumentContentProvider for glb json chunk.
+//
+export class GlbProvider implements vscode.TextDocumentContentProvider {
+
+    // emitter and its event
+    onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+    onDidChange = this.onDidChangeEmitter.event;
+
+    provideTextDocumentContent(uri: vscode.Uri): string {
+
+        let data = fs.readFileSync(uri.fsPath);
+        var offset = 0;
+        if (data.readInt32LE(offset) != 0x46546C67) {
+            return `not glb`;
+        }
+        offset += 4;
+
+        let version = data.readInt32LE(offset)
+        if (version != 2) {
+            return `gltf version ${version} not support`;
+        }
+        offset += 4;
+
+        let length = data.readInt32LE(offset);
+        offset += 4;
+
+        var json = null;
+        var binOffset = null;
+        while (offset < length) {
+
+            let chunkLength = data.readInt32LE(offset);
+            offset += 4;
+
+            let chunkType = data.readInt32LE(offset);
+            offset += 4;
+
+            let chunkData = data.toString('utf8', offset, offset + chunkLength);
+
+            if (chunkType == 0x4E4F534A) {
+
+                var json = JSON.parse(chunkData);
+
+            }
+            else if (chunkType == 0x004E4942) {
+
+                binOffset = offset;
+
+            }
+            else {
+                // unknown
+            }
+
+            offset += chunkLength;
+        }
+
+        if (binOffset && json) {
+
+            // buffer access hack
+            json.buffers[0]['uri'] = path.basename(uri.fsPath);
+            for (let bufferView of json.bufferViews) {
+                bufferView.byteOffset += binOffset;
+            }
+
+            return JSON.stringify(json, null, '  ');
+        }
+        else {
+
+            return `invalid glb`;
+
+        }
+    }
+};

--- a/src/glbProvider.ts
+++ b/src/glbProvider.ts
@@ -13,7 +13,12 @@ export class GlbProvider implements vscode.TextDocumentContentProvider {
 
     provideTextDocumentContent(uri: vscode.Uri): string {
 
-        let data = fs.readFileSync(uri.fsPath);
+        if (!uri.fsPath.endsWith(".json")) {
+            return "fsPath must endsWith .json";
+        }
+        let fsPath = uri.fsPath.substr(0, uri.fsPath.length - 5);
+
+        let data = fs.readFileSync(fsPath);
         let offset = 0;
         if (data.readInt32LE(offset) != 0x46546C67) {
             return `not glb`;
@@ -61,7 +66,7 @@ export class GlbProvider implements vscode.TextDocumentContentProvider {
         if (binOffset && json) {
 
             // buffer access hack
-            json.buffers[0]['uri'] = path.basename(uri.fsPath);
+            json.buffers[0]['uri'] = path.basename(fsPath);
             for (let bufferView of json.bufferViews) {
                 bufferView.byteOffset += binOffset;
             }

--- a/src/glbProvider.ts
+++ b/src/glbProvider.ts
@@ -14,7 +14,7 @@ export class GlbProvider implements vscode.TextDocumentContentProvider {
     provideTextDocumentContent(uri: vscode.Uri): string {
 
         let data = fs.readFileSync(uri.fsPath);
-        var offset = 0;
+        let offset = 0;
         if (data.readInt32LE(offset) != 0x46546C67) {
             return `not glb`;
         }
@@ -29,8 +29,8 @@ export class GlbProvider implements vscode.TextDocumentContentProvider {
         let length = data.readInt32LE(offset);
         offset += 4;
 
-        var json = null;
-        var binOffset = null;
+        let json = null;
+        let binOffset = null;
         while (offset < length) {
 
             let chunkLength = data.readInt32LE(offset);
@@ -43,7 +43,7 @@ export class GlbProvider implements vscode.TextDocumentContentProvider {
 
             if (chunkType == 0x4E4F534A) {
 
-                var json = JSON.parse(chunkData);
+                json = JSON.parse(chunkData);
 
             }
             else if (chunkType == 0x004E4942) {

--- a/src/glbTextDocumentContentProvider.ts
+++ b/src/glbTextDocumentContentProvider.ts
@@ -3,9 +3,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 //
-// Virtual TextDocumentContentProvider for glb json chunk.
+// GlbTextDocumentContentProvider provide json chunk of glb.
 //
-export class GlbProvider implements vscode.TextDocumentContentProvider {
+export class GlbTextDocumentContentProvider implements vscode.TextDocumentContentProvider {
 
     // emitter and its event
     onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();

--- a/src/gltfWindow.ts
+++ b/src/gltfWindow.ts
@@ -4,7 +4,15 @@ import { GltfInspectData } from './gltfInspectData';
 import { GltfOutline } from './gltfOutline';
 
 function isGltfFile(editor: vscode.TextEditor | undefined): boolean {
-    return editor && editor.document.fileName.toLowerCase().endsWith('.gltf');
+    if (editor) {
+        if (editor.document.fileName.toLowerCase().endsWith('.gltf')) {
+            return true;
+        }
+        if (editor.document.uri.scheme == 'glb') {
+            return true;
+        }
+    }
+    return false;
 }
 
 export class GltfWindow {


### PR DESCRIPTION
This pull request implement #218.

I was able to implement a glb preview by manipulating the offset so that the `buffer view` references the glb's bin chunk.

context_menu
![context_menu](https://user-images.githubusercontent.com/68057/119996852-16d20280-c00a-11eb-98c1-2a48b266d806.jpg)

![open_glb_directly](https://user-images.githubusercontent.com/68057/119996704-f73ada00-c009-11eb-9adf-35bdc73ae12b.jpg)

