### PR TITLE
limit Import/Validate context menu to .gltf/.glb

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,10 +230,12 @@
             "explorer/context": [
                 {
                     "command": "gltf.importGlbFile",
+                    "when": "resourceExtname == .gltf || resourceExtname == .glb",
                     "group": "glTF"
                 },
                 {
                     "command": "gltf.validateFile",
+                    "when": "resourceExtname == .gltf",
                     "group": "glTF"
                 }
             ],


### PR DESCRIPTION
I shouldn't get "glTF: Import from GLB" or "glTF: Validate a GLB or GLTF file" when clicking on a README.md ;-)

The commands are still available on F1 for those who want to use the file dialog.