### PR TITLE
Add QuickFix for undeclared extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### 2.3.13 - UNRELEASED
 
-* Update glTF schema to latest (document revision 2.0.1).
-* Added JSON schema for KHR_materials_emissive_strength, KHR_materials_iridescence, and KHR_xmp_json_ld.
-* Added the first "Quick Fix": Add an undeclared extension to `extensionsUsed`.
+* Update glTF schema to latest (document revision 2.0.1). [#226](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/226)
+* Added JSON schema for KHR_materials_emissive_strength, KHR_materials_iridescence, and KHR_xmp_json_ld. Included in [#226](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/226)
+* Added the first "Quick Fix": Add an undeclared extension to `extensionsUsed`. [#227](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/227)
 
 ### 2.3.12 - 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update glTF schema to latest (document revision 2.0.1).
 * Added JSON schema for KHR_materials_emissive_strength, KHR_materials_iridescence, and KHR_xmp_json_ld.
+* Added the first "Quick Fix": Add an undeclared extension to `extensionsUsed`.
 
 ### 2.3.12 - 2021-08-03
 

--- a/package.json
+++ b/package.json
@@ -178,6 +178,10 @@
                 "title": "glTF: Import from GLB"
             },
             {
+                "command": "gltf.declareExtension",
+                "title": "glTF: Add Extension to 'extensionsUsed'"
+            },
+            {
                 "command": "gltf.importAnimation",
                 "title": "glTF: Import animation"
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 import { DataUriTextDocumentContentProvider } from './dataUriTextDocumentContentProvider';
 import { ConvertGLBtoGltfLoadFirst, ConvertToGLB, getBuffer } from 'gltf-import-export';
-import * as Action from './gltfActionProvider';
+import { GltfActionProvider } from './gltfActionProvider';
 import * as GltfValidate from './validationProvider';
 import * as path from 'path';
 import * as Url from 'url';
@@ -363,8 +363,8 @@ export function activate(context: vscode.ExtensionContext): void {
     }));
 
     context.subscriptions.push(
-        vscode.languages.registerCodeActionsProvider('json', new Action.GltfActionProvider(), {
-            providedCodeActionKinds: Action.GltfActionProvider.providedCodeActionKinds
+        vscode.languages.registerCodeActionsProvider('json', new GltfActionProvider(), {
+            providedCodeActionKinds: GltfActionProvider.providedCodeActionKinds
         })
     );
 
@@ -507,7 +507,7 @@ export function activate(context: vscode.ExtensionContext): void {
             return;
         }
 
-        Action.GltfActionProvider.declareExtension(diagnostic, map);
+        GltfActionProvider.declareExtension(diagnostic, map);
     }));
 
     function getAnimationFromJsonPointer(glTF, jsonPointer: string): { json: any, path: string } {

--- a/src/gltfActionProvider.ts
+++ b/src/gltfActionProvider.ts
@@ -38,6 +38,9 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
         const activeTextEditor = vscode.window.activeTextEditor;
         const document = activeTextEditor.document;
         let searchRange: vscode.Range;
+
+        // This could be called by the QuickFix system, or just invoked directly
+        // by a user as an editor command.  Figure out where this was invoked.
         if (diagnostic) {
             searchRange = diagnostic.range;
         } else {
@@ -48,6 +51,8 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
             );
         }
 
+        // Next, figure out if we're on (or inside) a named extension, and
+        // what the extension name is.
         const pointers = map.pointers;
         let bestKey = '';
         for (let key of Object.keys(pointers)) {
@@ -81,6 +86,8 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
             return;
         }
 
+        // Now we know the extension name.  Figure out if there's already
+        // an "extensionsUsed" block, create one if not, and add the extension name to it.
         const eol = (document.eol === vscode.EndOfLine.CRLF) ? '\r\n' : '\n';
         const tabSize = activeTextEditor.options.tabSize as number;
         const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';

--- a/src/gltfActionProvider.ts
+++ b/src/gltfActionProvider.ts
@@ -1,0 +1,127 @@
+import * as vscode from 'vscode';
+import { JsonMap } from './utilities';
+import { GLTF2 } from './GLTF2';
+
+// This file offers "Quick Fixes" for select validation issues.
+
+const GLTF_VALIDATOR = 'glTF Validator';
+const UNDECLARED_EXTENSION = 'UNDECLARED_EXTENSION';
+const ADD_EXTENSION = 'Add Extension to \'extensionsUsed\'';
+
+export class GltfActionProvider implements vscode.CodeActionProvider {
+
+    public static readonly providedCodeActionKinds = [
+        vscode.CodeActionKind.QuickFix
+    ];
+
+    provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.CodeAction[] {
+        // for each diagnostic entry that has the matching `code`, create a code action command
+        return context.diagnostics
+            .filter(diagnostic => diagnostic.source === GLTF_VALIDATOR && diagnostic.code === UNDECLARED_EXTENSION)
+            .map(diagnostic => this.createCommandDeclareExtension(diagnostic));
+    }
+
+    private createCommandDeclareExtension(diagnostic: vscode.Diagnostic): vscode.CodeAction {
+        const action = new vscode.CodeAction(ADD_EXTENSION, vscode.CodeActionKind.QuickFix);
+        action.command = {
+            command: 'gltf.declareExtension',
+            arguments: [diagnostic],
+            title: ADD_EXTENSION,
+            tooltip: 'Add this extension to the extensionsUsed array.'
+        };
+        action.diagnostics = [diagnostic];
+        action.isPreferred = true;
+        return action;
+    }
+
+    public static declareExtension(diagnostic: vscode.Diagnostic, map: JsonMap<GLTF2.GLTF>): void {
+        const activeTextEditor = vscode.window.activeTextEditor;
+        const document = activeTextEditor.document;
+        let searchRange: vscode.Range;
+        if (diagnostic) {
+            searchRange = diagnostic.range;
+        } else {
+            const selection = activeTextEditor.selection;
+            searchRange = new vscode.Range(
+                selection.active,
+                selection.active
+            );
+        }
+
+        const pointers = map.pointers;
+        let bestKey = '';
+        for (let key of Object.keys(pointers)) {
+            let pointer = pointers[key];
+
+            if (pointer.key) {
+                const range = new vscode.Range(
+                    document.positionAt(pointer.key.pos),
+                    document.positionAt(pointer.valueEnd.pos)
+                );
+
+                if (range.contains(searchRange)) {
+                    bestKey = key;
+                }
+            }
+        }
+
+        let pos = bestKey.lastIndexOf('/extensions/');
+        if (pos < 0) {
+            return;
+        }
+
+        let extensionName = bestKey.substring(pos + 12);
+        let pos2 = extensionName.indexOf('/');
+        if (pos2 >= 0)
+        {
+            extensionName = extensionName.substring(0, pos2);
+        }
+
+        if (extensionName === '') {
+            return;
+        }
+
+        const eol = (document.eol === vscode.EndOfLine.CRLF) ? '\r\n' : '\n';
+        const tabSize = activeTextEditor.options.tabSize as number;
+        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';
+        let insert = -1;
+        let newJson: string;
+
+        if (pointers['/extensionsUsed'] !== undefined) {
+            // Add extension name to existing extensionsUsed list.
+
+            for (let key of Object.keys(pointers)) {
+                if (key.startsWith('/extensionsUsed/')) {
+                    insert = Math.max(insert, pointers[key].valueEnd.pos);
+                }
+            }
+
+            if (insert < 0) {
+                return;
+            }
+
+            newJson =
+                ',' + eol +
+                space + space + '"' + extensionName + '"';
+
+        } else {
+            // Create a new extensionsUsed section.
+
+            for (let key of Object.keys(pointers)) {
+                if (key.length > 2) {
+                    insert = Math.max(insert, pointers[key].valueEnd.pos);
+                }
+            }
+
+            newJson =
+                ',' + eol +
+                space + '"extensionsUsed": [' + eol +
+                space + space + '"' + extensionName + '"' + eol +
+                space + ']';
+        }
+
+        activeTextEditor.edit(editBuilder => {
+            editBuilder.insert(document.positionAt(insert), newJson);
+        });
+    }
+}

--- a/src/gltfActionProvider.ts
+++ b/src/gltfActionProvider.ts
@@ -103,13 +103,16 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
                 }
             }
 
-            if (insert < 0) {
-                return;
-            }
-
             newJson =
                 ',' + eol +
                 space + space + '"' + extensionName + '"';
+
+            if (insert < 0) {
+                // This block only executes if "extensionsUsed" is an empty array,
+                // which is invalid glTF, but possible in the editor.
+                insert = pointers['/extensionsUsed'].value.pos + 1;
+                newJson = newJson.substring(1);
+            }
 
         } else {
             // Create a new extensionsUsed section.

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -173,6 +173,8 @@ export interface JsonMap<T> {
     data: T;
     pointers: {
         [pointer: string]: {
+            key?: JsonMapPointerValue,
+            keyEnd?: JsonMapPointerValue,
             value: JsonMapPointerValue,
             valueEnd: JsonMapPointerValue
         }


### PR DESCRIPTION
When you add a new extension to a glTF file, the validator will typically say:

> Extension is not declared in extensionsUsed. _glTF Validator(UNDECLARED_EXTENSION)_

This PR adds a "Quick Fix..." option (via the little lightbulb icon that provides such fixes) to add the extension to the `extensionsUsed` array, automatically creating such an array if it doesn't exist.
