### PR TITLE
Update "when" commands are available in certain contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Update glTF schema to latest (document revision 2.0.1). [#226](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/226)
 * Added JSON schema for KHR_materials_emissive_strength, KHR_materials_iridescence, and KHR_xmp_json_ld. Included in [#226](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/226)
 * Added the first "Quick Fix": Add an undeclared extension to `extensionsUsed`. [#227](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/227)
+* Changed when certain commands appear in certain menus. [#228](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/228)
+* Import (convert .glb to .gltf) and export (convert .gltf to .glb) are now available from VSCode's file explorer window context menu. Included in [#228](https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/228)
 
 ### 2.3.12 - 2021-08-03
 

--- a/package.json
+++ b/package.json
@@ -233,11 +233,18 @@
         "menus": {
             "explorer/context": [
                 {
+                    "command": "gltf.exportGlbFile",
+                    "when": "resourceExtname == .gltf",
+                    "group": "glTF"
+                },
+                {
                     "command": "gltf.importGlbFile",
+                    "when": "resourceExtname == .glb",
                     "group": "glTF"
                 },
                 {
                     "command": "gltf.validateFile",
+                    "when": "resourceExtname == .gltf || resourceExtname == .glb",
                     "group": "glTF"
                 }
             ],
@@ -249,6 +256,16 @@
                 },
                 {
                     "command": "gltf.inspectData",
+                    "when": "gltfFileActive",
+                    "group": "glTF"
+                },
+                {
+                    "command": "gltf.importUri",
+                    "when": "gltfFileActive",
+                    "group": "glTF"
+                },
+                {
+                    "command": "gltf.exportUri",
                     "when": "gltfFileActive",
                     "group": "glTF"
                 }
@@ -272,36 +289,18 @@
             ],
             "editor/title/context": [
                 {
-                    "command": "gltf.previewModel",
-                    "when": "gltfFileActive",
-                    "group": "glTF"
-                },
-                {
-                    "command": "gltf.inspectData",
-                    "when": "gltfFileActive",
-                    "group": "glTF"
-                },
-                {
-                    "command": "gltf.importUri",
-                    "when": "gltfFileActive",
-                    "group": "glTF"
-                },
-                {
-                    "command": "gltf.exportUri",
-                    "when": "gltfFileActive",
-                    "group": "glTF"
-                },
-                {
                     "command": "gltf.exportGlbFile",
-                    "when": "gltfFileActive",
+                    "when": "resourceExtname == .gltf",
                     "group": "glTF"
                 },
                 {
                     "command": "gltf.importGlbFile",
+                    "when": "resourceExtname == .glb",
                     "group": "glTF"
                 },
                 {
                     "command": "gltf.validateFile",
+                    "when": "resourceExtname == .gltf || resourceExtname == .glb",
                     "group": "glTF"
                 }
             ],

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -63,7 +63,7 @@ var mainViewModel = window.mainViewModel = {
     },
     showErrorMessage: (message) => window.vscode.postMessage({ command: 'showErrorMessage', message: message }),
     showWarningMessage: (message) => window.vscode.postMessage({ command: 'showWarningMessage', message: message }),
-    setContext: (name, value) => window.vscode.postMessage({ command: 'setContext', name: name, value: value }),
+    setDebugActive: (value) => window.vscode.postMessage({ command: 'setDebugActive', value: value }),
     onReady: () => window.vscode.postMessage({ command: 'onReady' })
 };
 
@@ -150,7 +150,7 @@ function initPreview()
                         activeView.disableDebugMode();
                         mainUI.style.display = 'block';
                     }
-                    mainViewModel.setContext('gltfDebugActive', activeView.isDebugModeEnabled());
+                    mainViewModel.setDebugActive(activeView.isDebugModeEnabled());
                 }
                 else {
                     mainViewModel.showWarningMessage('Only Babylon.js supports debug mode');
@@ -159,7 +159,7 @@ function initPreview()
             }
             case 'updateDebugMode': {
                 if (mainViewModel.selectedEngine().name === 'Babylon.js') {
-                    mainViewModel.setContext('gltfDebugActive', activeView.isDebugModeEnabled());
+                    mainViewModel.setDebugActive(activeView.isDebugModeEnabled());
                 }
                 break;
             }

--- a/src/gltfActionProvider.ts
+++ b/src/gltfActionProvider.ts
@@ -34,9 +34,9 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
         return action;
     }
 
-    public static declareExtension(diagnostic: vscode.Diagnostic, map: JsonMap<GLTF2.GLTF>): void {
-        const activeTextEditor = vscode.window.activeTextEditor;
-        const document = activeTextEditor.document;
+    public static declareExtension(diagnostic: vscode.Diagnostic, map: JsonMap<GLTF2.GLTF>,
+        textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit): void {
+        const document = textEditor.document;
         let searchRange: vscode.Range;
 
         // This could be called by the QuickFix system, or just invoked directly
@@ -44,7 +44,7 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
         if (diagnostic) {
             searchRange = diagnostic.range;
         } else {
-            const selection = activeTextEditor.selection;
+            const selection = textEditor.selection;
             searchRange = new vscode.Range(
                 selection.active,
                 selection.active
@@ -89,8 +89,8 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
         // Now we know the extension name.  Figure out if there's already
         // an "extensionsUsed" block, create one if not, and add the extension name to it.
         const eol = (document.eol === vscode.EndOfLine.CRLF) ? '\r\n' : '\n';
-        const tabSize = activeTextEditor.options.tabSize as number;
-        const space = activeTextEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';
+        const tabSize = textEditor.options.tabSize as number;
+        const space = textEditor.options.insertSpaces ? (new Array(tabSize + 1).join(' ')) : '\t';
         let insert = -1;
         let newJson: string;
 
@@ -130,8 +130,6 @@ export class GltfActionProvider implements vscode.CodeActionProvider {
                 space + ']';
         }
 
-        activeTextEditor.edit(editBuilder => {
-            editBuilder.insert(document.positionAt(insert), newJson);
-        });
+        edit.insert(document.positionAt(insert), newJson);
     }
 }

--- a/src/gltfPreview.ts
+++ b/src/gltfPreview.ts
@@ -188,8 +188,8 @@ export class GltfPreview extends ContextBase {
                 vscode.commands.executeCommand('gltf.openGltfSelection', range);
                 break;
             }
-            case 'setContext': {
-                vscode.commands.executeCommand('setContext', message.name, message.value);
+            case 'setDebugActive': {
+                vscode.commands.executeCommand('setContext', 'gltfDebugActive', message.value);
                 break;
             }
             case 'showErrorMessage': {


### PR DESCRIPTION
This refines when import (GLB-to-gltf) and export (gltf-to-GLB) commands appear in certain menus, and generally tries to make a cleaner distinction between `registerCommand` vs. `registerTextEditorCommand`.

- Import (convert .glb to .gltf) and export (convert .gltf to .glb) are now available from VSCode's file explorer window context menu, and all operate on the chosen file (not the active editor, as the "export" command previously did).
- glTF-related commands shouldn't appear in context menus of files without .gltf/.glb extensions.
- Preview/Inspect/DataURI commands are no longer available in the title-bar context menu, because they only operate on the active editor.  They are available from the editor text context menu, the command pallette, and still assigned the same keyboard shortcuts as before.

Superscedes #225.