### PR TITLE
add Z-Up axis support for Babylon.js preview

### DIFF
--- a/pages/babylonView.js
+++ b/pages/babylonView.js
@@ -15,6 +15,7 @@
         var skybox = null;
         var skyboxBlur = 0.0;
         var backgroundSubscription = null;
+        var axisSubscription = null;
         var debug = null;
 
         /**
@@ -31,6 +32,10 @@
             if (backgroundSubscription) {
                 backgroundSubscription.dispose();
                 backgroundSubscription = null;
+            }
+            if (axisSubscription) {
+                axisSubscription.dispose();
+                axisSubscription = null;
             }
 
             mainViewModel.animations([]);
@@ -167,6 +172,25 @@
                 }
                 applyBackground(mainViewModel.showBackground());
                 backgroundSubscription = mainViewModel.showBackground.subscribe(applyBackground);
+
+                function updateAxisOrientation(isZUp) {
+                    scene.activeCamera.upVector = isZUp ? new BABYLON.Vector3(0, 0, 1) : new BABYLON.Vector3(0, 1, 0);
+                    var rotationMatrix = isZUp ? BABYLON.Matrix.RotationX(-Math.PI / 2) : BABYLON.Matrix.Identity();
+                    if (scene.environmentTexture) {
+                        scene.environmentTexture.setReflectionTextureMatrix(rotationMatrix);
+                    }
+                    if (skybox && skybox.material && skybox.material.reflectionTexture) {
+                        skybox.material.reflectionTexture.setReflectionTextureMatrix(rotationMatrix);
+                    }
+                    scene.materials.forEach(mat => {
+                        if (mat.reflectionTexture) {
+                            mat.reflectionTexture.setReflectionTextureMatrix(rotationMatrix);
+                        }
+                        if (mat.markDirty) mat.markDirty();
+                    });
+                }
+                updateAxisOrientation(mainViewModel.isZUp());
+                axisSubscription = mainViewModel.isZUp.subscribe(updateAxisOrientation);
 
                 engine.runRenderLoop(render);
 

--- a/pages/previewModel.html
+++ b/pages/previewModel.html
@@ -27,6 +27,13 @@
                 <span>Show Background</span>
             </label>
         </div>
+        <div class="rowUI" data-bind="visible: selectedEngine() && selectedEngine().name === 'Babylon.js'">
+            <label class="checkboxLabel" data-bind="css: { active: isZUp() }">
+                <input type="checkbox" data-bind="checked: isZUp" />
+                <span class="angleBox"><span></span></span>
+                <span>Z-Up Axis</span>
+            </label>
+        </div>
         <div class="rowUI" style="display: none;" data-bind="visible: animations().length > 0">
             <div class="smallHeading">animations:</div>
             <div class="embeddedList" data-bind="foreach: animations">

--- a/pages/previewModel.js
+++ b/pages/previewModel.js
@@ -43,6 +43,7 @@ var mainViewModel = window.mainViewModel = {
     showControls: ko.observable(true),
     hasBackground: ko.observable(false),
     showBackground: ko.observable(false),
+    isZUp: ko.observable(false),
     toggleControls: () => mainViewModel.showControls(!mainViewModel.showControls()),
     controlText: () => (mainViewModel.showControls() ? 'Close Controls' : 'Open Controls'),
     animations: ko.observableArray([]),


### PR DESCRIPTION
This PR introduces a "Z-Up Axis" toggle in the Babylon.js preview settings.
<img width="1555" height="910" alt="Example" src="https://github.com/user-attachments/assets/9f5c54ab-db69-4b61-a26b-f92f4caf6776" />

### Motivation:
Many game engines (e.g., Unreal Engine, custom Z-Up engines) and 3D tools (like Blender) natively use a Z-Up coordinate system. When developers export glTF models using Z-Up data to keep it consistent with their engine's internal coordinate system, the standard Y-Up preview in VS Code renders the model lying on its side.
While glTF is strictly Y-Up by specification, providing a preview-only axis correction allows developers to verify their assets more easily without adding unnecessary root rotation nodes to the source file.


### Key Changes:
Added a Z-Up Axis checkbox to the Main UI (only visible when Babylon.js is selected).
Implemented coordinate swizzling for:
camera.upVector
skybox mesh rotation
environmentTexture and material reflection matrices
The toggle state is managed via MainViewModel for real-time updates.

### How to Test
Open a glTF model.
Open the Babylon.js preview (Alt + G).
Find the "Z Up Axis" checkbox in the UI panel.
Toggle it to see the model, skybox, and IBL orientation switch between Y-Up and Z-Up.